### PR TITLE
Add "aria" to data attributes.

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -94,7 +94,7 @@ class Html
      * In particular, if the value of the `data` attribute is `['name' => 'xyz', 'age' => 13]`, two attributes will be
      * generated instead of one: `data-name="xyz" data-age="13"`.
      */
-    protected const DATA_ATTRIBUTES = ['data', 'data-ng', 'ng'];
+    protected const DATA_ATTRIBUTES = ['data', 'data-ng', 'ng', 'aria'];
 
     /**
      * Encodes special characters into HTML entities.

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -1126,6 +1126,7 @@ EOD;
         $this->assertSame('<link src="xyz" data-a="1" data-b="c">', Html::tag('link', '', ['src' => 'xyz', 'data' => ['a' => 1, 'b' => 'c']]));
         $this->assertSame('<link src="xyz" ng-a="1" ng-b="c">', Html::tag('link', '', ['src' => 'xyz', 'ng' => ['a' => 1, 'b' => 'c']]));
         $this->assertSame('<link src="xyz" data-ng-a="1" data-ng-b="c">', Html::tag('link', '', ['src' => 'xyz', 'data-ng' => ['a' => 1, 'b' => 'c']]));
+        $this->assertSame('<link src="xyz" aria-a="1" aria-b="c">', Html::tag('link', '', ['src' => 'xyz', 'aria' => ['a' => 1, 'b' => 'c']]));
         $this->assertSame('<link src=\'{"a":1,"b":"It\\u0027s"}\'>', Html::tag('link', '', ['src' => ['a' => 1, 'b' => "It's"]]));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -

Allow set `aria-` attriubtes ([info](https://www.w3.org/TR/wai-aria-1.1/#state_prop_def)) as array. For example:

```php
Html::tag('div', '', ['aria' => ['a' => 1, 'b' => 'c']])); // <div aria-a="1" aria-b="c"></div>
```
