### PR TITLE
Add option "wrapInput" for checkbox and radio + tests

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -790,8 +790,8 @@ class Html
      *   When this option is specified, the checkbox will be enclosed by a label tag.
      * - labelOptions: array, the HTML attributes for the label tag. Do not set this option unless you set the "label"
      *   option.
-     * - wrapOptions: bool, use when has label.
-     *   if `wrapOptions` is true result will be `<label><input> Label</label>`,
+     * - wrapInput: bool, use when has label.
+     *   if `wrapInput` is true result will be `<label><input> Label</label>`,
      *   else `<input> <label>Label</label>`
      *
      * The rest of the options will be rendered as the attributes of the resulting checkbox tag. The values will be

--- a/src/Html.php
+++ b/src/Html.php
@@ -790,6 +790,9 @@ class Html
      *   When this option is specified, the checkbox will be enclosed by a label tag.
      * - labelOptions: array, the HTML attributes for the label tag. Do not set this option unless you set the "label"
      *   option.
+     * - wrapOptions: bool, use when has label.
+     *   if `wrapOptions` is true result will be `<label><input> Label</label>`,
+     *   else `<input> <label>Label</label>`
      *
      * The rest of the options will be rendered as the attributes of the resulting checkbox tag. The values will be
      * HTML-encoded using {@see encode()}. If a value is null, the corresponding attribute will not be rendered.
@@ -821,15 +824,27 @@ class Html
             $hidden = '';
         }
 
-        if (isset($options['label'])) {
-            $label = $options['label'];
-            $labelOptions = $options['labelOptions'] ?? [];
-            unset($options['label'], $options['labelOptions']);
-            $content = static::label(static::input($type, $name, $value, $options) . ' ' . $label, null, $labelOptions);
-            return $hidden . $content;
+        $label = $options['label'] ?? null;
+        $labelOptions = $options['labelOptions'] ?? [];
+        $wrapInput = $options['wrapInput'] ?? true;
+        unset($options['label'], $options['labelOptions'], $options['wrapInput']);
+
+        if (empty($label)) {
+            return $hidden . static::input($type, $name, $value, $options);
         }
 
-        return $hidden . static::input($type, $name, $value, $options);
+        if ($wrapInput) {
+            $input = static::input($type, $name, $value, $options);
+            return $hidden . static::label($input . ' ' . $label, null, $labelOptions);
+        }
+
+        if (!isset($options['id'])) {
+            $options['id'] = static::generateId();
+        }
+        return $hidden .
+            static::input($type, $name, $value, $options) .
+            ' ' .
+            static::label($label, $options['id'], $labelOptions);
     }
 
     /**

--- a/src/Html.php
+++ b/src/Html.php
@@ -103,9 +103,7 @@ class Html
             $counter = ++static::$generateIdCounter[$prefix];
         } else {
             $counter = 1;
-            static::$generateIdCounter = [
-                $prefix => $counter,
-            ];
+            static::$generateIdCounter = [$prefix => $counter];
         }
         return $prefix . $counter;
     }

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -8,6 +8,10 @@ use Yiisoft\Html\Html;
 
 final class HtmlTest extends TestCase
 {
+    /**
+     * Use different values in different tests
+     * @var mixed
+     */
     public static $hrtimeResult;
 
     protected function setUp(): void
@@ -21,10 +25,10 @@ final class HtmlTest extends TestCase
         $this->assertMatchesRegularExpression('/i\d+/', Html::generateId());
         $this->assertMatchesRegularExpression('/test\d+/', Html::generateId('test'));
 
-        static::$hrtimeResult = '123';
+        static::$hrtimeResult = 123;
         $this->assertSame('i1231', Html::generateId());
         $this->assertSame('i1232', Html::generateId());
-        static::$hrtimeResult = '124';
+        static::$hrtimeResult = 124;
         $this->assertSame('i1241', Html::generateId());
     }
 
@@ -364,6 +368,26 @@ final class HtmlTest extends TestCase
             'label' => 'ccc',
             'value' => 2,
         ]));
+
+        $this->assertSame(
+            '<input type="radio" id="UseThis" name="test" checked> <label for="UseThis">Use this</label>',
+            Html::radio('test', true, [
+                'id' => 'UseThis',
+                'label' => 'Use this',
+                'value' => null,
+                'wrapInput' => false,
+            ])
+        );
+
+        static::$hrtimeResult = 42;
+        $this->assertSame(
+            '<input type="radio" id="i421" name="test" checked> <label for="i421">Use this</label>',
+            Html::radio('test', true, [
+                'label' => 'Use this',
+                'value' => null,
+                'wrapInput' => false,
+            ])
+        );
     }
 
     public function testCheckbox(): void
@@ -400,6 +424,26 @@ final class HtmlTest extends TestCase
             'value' => 2,
             'form' => 'test-form',
         ]));
+
+        $this->assertSame(
+            '<input type="checkbox" id="UseThis" name="test"> <label for="UseThis">Use this</label>',
+            Html::checkbox('test', false, [
+                'id' => 'UseThis',
+                'label' => 'Use this',
+                'value' => null,
+                'wrapInput' => false,
+            ])
+        );
+
+        static::$hrtimeResult = 49;
+        $this->assertSame(
+            '<input type="checkbox" id="i491" name="test"> <label for="i491">Use this</label>',
+            Html::checkbox('test', false, [
+                'label' => 'Use this',
+                'value' => null,
+                'wrapInput' => false,
+            ])
+        );
     }
 
     public function testDropDownList(): void

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -8,10 +8,24 @@ use Yiisoft\Html\Html;
 
 final class HtmlTest extends TestCase
 {
+    public static $hrtimeResult;
+
+    protected function setUp(): void
+    {
+        static::$hrtimeResult = null;
+        parent::setUp();
+    }
+
     public function testGenerateId(): void
     {
         $this->assertMatchesRegularExpression('/i\d+/', Html::generateId());
         $this->assertMatchesRegularExpression('/test\d+/', Html::generateId('test'));
+
+        static::$hrtimeResult = '123';
+        $this->assertSame('i1231', Html::generateId());
+        $this->assertSame('i1232', Html::generateId());
+        static::$hrtimeResult = '124';
+        $this->assertSame('i1241', Html::generateId());
     }
 
     public function testEncode(): void
@@ -1195,4 +1209,13 @@ EOD;
             Html::escapeJsRegularExpression($regexp)
         );
     }
+}
+
+namespace Yiisoft\Html;
+
+use Yiisoft\Html\Tests\HtmlTest;
+
+function hrtime(bool $getAsNumber = false)
+{
+    return HtmlTest::$hrtimeResult ?? \hrtime($getAsNumber);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -

Add option `wrapInput` for checkbox and radio.

`wrapInput` use when has label.
if `wrapInput` is true result will be `<label><input> Label</label>`,  else `<input> <label>Label</label>`.

+ more tests for `Html::generateId()`