### PR TITLE
Remove Html::escapeJsRegularExpression and add Html::normalizeRegexpPattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Overall the helper has the following method groups.
 - endTag
 - tag
 - renderTagAttributes
+- normalizeRegexpPattern
 
 ### Generating base tags
 
@@ -141,7 +142,6 @@ Overall the helper has the following method groups.
 ### Other
 
 - generateId
-- escapeJsRegularExpression
 
 ## Testing
 

--- a/src/Html.php
+++ b/src/Html.php
@@ -1619,31 +1619,6 @@ final class Html
     }
 
     /**
-     * Escapes regular expression to use in JavaScript.
-     *
-     * @param string $regexp the regular expression to be escaped.
-     *
-     * @return string the escaped result.
-     */
-    public static function escapeJsRegularExpression(string $regexp): string
-    {
-        $pattern = preg_replace('/\\\\x{?([0-9a-fA-F]+)}?/', '\u$1', $regexp);
-        $deliminator = substr($pattern, 0, 1);
-        $pos = (int)strrpos($pattern, $deliminator, 1);
-        $flag = $pos > 0 ? substr($pattern, $pos + 1) : '';
-        if ($deliminator !== '/') {
-            $pattern = '/' . str_replace('/', '\\/', substr($pattern, 1, $pos - 1)) . '/';
-        } else {
-            $pattern = substr($pattern, 0, $pos + 1);
-        }
-        if (!empty($flag)) {
-            $pattern .= preg_replace('/[^igm]/', '', $flag);
-        }
-
-        return $pattern;
-    }
-
-    /**
      * Normalize PCRE regular expression to use in the "pattern" HTML attribute:
      *  - convert \x{FFFF} to \uFFFF;
      *  - remove flags and delimiters.

--- a/src/Html.php
+++ b/src/Html.php
@@ -1637,6 +1637,10 @@ final class Html
      */
     public static function normalizeRegexpPattern(string $regexp, ?string $delimiter = null): string
     {
+        if (strlen($regexp) < 2) {
+            throw new InvalidArgumentException('Incorrect regular expression.');
+        }
+
         $pattern = preg_replace('/\\\\x{?([0-9a-fA-F]+)}?/', '\u$1', $regexp);
 
         if ($delimiter === null) {
@@ -1645,7 +1649,11 @@ final class Html
             throw new InvalidArgumentException('Incorrect delimiter.');
         }
 
-        $endPosition = strrpos($pattern, $delimiter, 1);
+        try {
+            $endPosition = strrpos($pattern, $delimiter, 1);
+        } catch (\ValueError $e) { // For PHP 8
+            $endPosition = false;
+        }
         if ($endPosition === false) {
             throw new InvalidArgumentException('Incorrect regular expression.');
         }

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -1220,32 +1220,6 @@ EOD;
         ];
     }
 
-    public function escapeJsRegularExpressionData(): array
-    {
-        return [
-            ['/[a-z0-9-]+/', '([a-z0-9-]+)'],
-            ['/[igm]+/', '([igm]+)'],
-            ['/([a-z0-9-]+)/gim', '/([a-z0-9-]+)/Ugimex'],
-            ['/mag/img', '/mag/imgx'],
-            ['/[a-z0-9-\\/]+/', '([a-z0-9-/]+)'],
-            ['/(.*)/m', 'g(.*)gm'],
-        ];
-    }
-
-    /**
-     * @dataProvider escapeJsRegularExpressionData
-     *
-     * @param string $expected
-     * @param string $regexp
-     */
-    public function testEscapeJsRegularExpression(string $expected, string $regexp): void
-    {
-        $this->assertSame(
-            $expected,
-            Html::escapeJsRegularExpression($regexp)
-        );
-    }
-
     public function dataNormalizeRegexpPattern(): array
     {
         return [

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Html\Tests;
 
+use InvalidArgumentException;
 use Yiisoft\Html\Html;
 
 final class HtmlTest extends TestCase
@@ -1243,6 +1244,55 @@ EOD;
             $expected,
             Html::escapeJsRegularExpression($regexp)
         );
+    }
+
+    public function dataNormalizeRegexpPattern(): array
+    {
+        return [
+            ['', '//'],
+            ['.*', '/.*/'],
+            ['([a-z0-9-]+)', '/([a-z0-9-]+)/Ugimex'],
+            ['([a-z0-9-]+)', '~([a-z0-9-]+)~Ugimex'],
+            ['([a-z0-9-]+)', '~([a-z0-9-]+)~Ugimex', '~'],
+            ['\u1F596([a-z])', '/\x{1F596}([a-z])/i'],
+        ];
+    }
+
+    /**
+     * @dataProvider dataNormalizeRegexpPattern
+     *
+     * @param string $expected
+     * @param string $regexp
+     * @param string|null $delimiter
+     */
+    public function testNormalizeRegexpPattern(string $expected, string $regexp, ?string $delimiter = null): void
+    {
+        $this->assertSame($expected, Html::normalizeRegexpPattern($regexp, $delimiter));
+    }
+
+    public function dataNormalizeRegexpPatternInvalid(): array
+    {
+        return [
+            [''],
+            ['.*'],
+            ['/.*'],
+            ['([a-z0-9-]+)'],
+            ['/.*/i', '~'],
+            ['/.*/i', '//'],
+            ['/~~/i', '~~'],
+        ];
+    }
+
+    /**
+     * @dataProvider dataNormalizeRegexpPatternInvalid
+     *
+     * @param string $regexp
+     * @param string|null $delimiter
+     */
+    public function testNormalizeRegexpPatternInvalid(string $regexp, ?string $delimiter = null): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        Html::normalizeRegexpPattern($regexp, $delimiter);
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | #23 

- Remove `Html::escapeJsRegularExpression`
- Add `Html::normalizeRegexpPattern`