### PR TITLE
Add encode methods for different contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Overall the helper has the following method groups.
 - encode
 - encodeAttribute
 - encodeUnquotedAttribute
-- escapeJsStringValue
+- escapeJavaScriptStringValue
 
 ### Other
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Overall the helper has the following method groups.
 
 ### Encode and escape special characters
 
-- encodeContent
+- encode
 - encodeAttribute
 - encodeQuotedAttribute
 - escapeJsStringValue

--- a/README.md
+++ b/README.md
@@ -134,11 +134,12 @@ Overall the helper has the following method groups.
 - cssStyleFromArray
 - cssStyleToArray
 
-### Encode and decode special characters
+### Encode, decode and escape special characters
 
 - encodeContent
 - encodeAttribute
 - encodeQuotedAttribute
+- escapeJsStringValue
 - encode
 - decode
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Overall the helper has the following method groups.
 
 - encode
 - encodeAttribute
-- encodeQuotedAttribute
+- encodeUnquotedAttribute
 - escapeJsStringValue
 
 ### Other

--- a/README.md
+++ b/README.md
@@ -134,14 +134,12 @@ Overall the helper has the following method groups.
 - cssStyleFromArray
 - cssStyleToArray
 
-### Encode, decode and escape special characters
+### Encode and escape special characters
 
 - encodeContent
 - encodeAttribute
 - encodeQuotedAttribute
 - escapeJsStringValue
-- encode
-- decode
 
 ### Other
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ Overall the helper has the following method groups.
 
 ### Encode and decode special characters
 
+- encodeContent
+- encodeAttribute
 - encode
 - decode
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Overall the helper has the following method groups.
 
 - encodeContent
 - encodeAttribute
+- encodeQuotedAttribute
 - encode
 - decode
 

--- a/src/Html.php
+++ b/src/Html.php
@@ -152,7 +152,7 @@ final class Html
 
     /**
      * Encodes special characters in value into HTML entities for use as tag content.
-     * Encode symbols: &, <, >.
+     * Encode characters: &, <, >.
      *
      * @param mixed $content the content to be encoded
      * @param bool $doubleEncode if already encoded entities should be encoded
@@ -173,7 +173,7 @@ final class Html
 
     /**
      * Encodes special characters in value into HTML entities for use as attribute value of tag.
-     * Encode symbols: &, <, >, ", ', `, =, tab, space, U+000A (form feed), U+0000 (null).
+     * Encode characters: &, <, >, ", ', `, =, tab, space, U+000A (form feed), U+0000 (null).
      *
      * @param mixed $value the attribute value to be encoded
      * @param bool $doubleEncode if already encoded entities should be encoded
@@ -206,7 +206,7 @@ final class Html
 
     /**
      * Encodes special characters in value into HTML entities for use as quoted attribute value of tag.
-     * Encode symbols: &, <, >, ", ', U+0000 (null).
+     * Encode characters: &, <, >, ", ', U+0000 (null).
      *
      * @param mixed $value the attribute value to be encoded
      * @param bool $doubleEncode if already encoded entities should be encoded
@@ -227,6 +227,29 @@ final class Html
 
         return strtr($value, [
             "\u{0000}" => '&#0;', // U+0000 NULL
+        ]);
+    }
+
+    /**
+     * Escape special characters in value for use as string value in javascipt into tag script.
+     * For example:
+     *
+     * ```
+     * <script type="text/javascript">
+     *     window.myVar = "<?= Html::escapeJsStringValue($myVar) ?>";
+     * </script>
+     * ```
+     *
+     * @param mixed $value
+     * @return string
+     */
+    public static function escapeJsStringValue($value): string
+    {
+        return strtr((string)$value, [
+            '/' => '\/',
+            '"' => '\"',
+            "'" => "\'",
+            '\\' => '\\\\',
         ]);
     }
 

--- a/src/Html.php
+++ b/src/Html.php
@@ -167,7 +167,7 @@ final class Html
 
     /**
      * Encodes special characters in value into HTML entities for use as attribute value of tag.
-     * Encode symbols: &, <, >, ", '.
+     * Encode symbols: &, <, >, ", ', ` and space.
      *
      * @param mixed $value the attribute value to be encoded
      * @param bool $doubleEncode if already encoded entities should be encoded
@@ -175,6 +175,30 @@ final class Html
      * @return string
      */
     public static function encodeAttribute($value, $doubleEncode = true, string $encoding = 'UTF-8'): string
+    {
+        $value = htmlspecialchars(
+            (string)$value,
+            ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5,
+            $encoding,
+            $doubleEncode
+        );
+
+        return strtr($value, [
+            ' ' => '&#32;',
+            '`' => '&grave;',
+        ]);
+    }
+
+    /**
+     * Encodes special characters in value into HTML entities for use as quoted attribute value of tag.
+     * Encode symbols: &, <, >, ", '.
+     *
+     * @param mixed $value the attribute value to be encoded
+     * @param bool $doubleEncode if already encoded entities should be encoded
+     * @param string $encoding the encoding to use, defaults to "UTF-8"
+     * @return string
+     */
+    public static function encodeQuotedAttribute($value, $doubleEncode = true, string $encoding = 'UTF-8'): string
     {
         return htmlspecialchars(
             (string)$value,
@@ -192,8 +216,8 @@ final class Html
      * @param string $content the content to be enclosed between the start and end tags. It will not be HTML-encoded.
      * If this is coming from end users, you should consider {@see encodeContent()} it to prevent XSS attacks.
      * @param array $options the HTML tag attributes (HTML options) in terms of name-value pairs. These will be
-     * rendered as the attributes of the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}.
-     * If a value is null, the corresponding attribute will not be rendered.
+     * rendered as the attributes of the resulting tag. The values will be HTML-encoded using
+     * {@see encodeQuotedAttribute()}. If a value is null, the corresponding attribute will not be rendered.
      *
      * For example when using `['class' => 'my-class', 'target' => '_blank', 'value' => null]` it will result in the
      * HTML attributes rendered like this: `class="my-class" target="_blank"`.
@@ -224,8 +248,8 @@ final class Html
      * @param string|bool|null $name the tag name. If $name is `null` or `false`, the corresponding content will be
      * rendered without any tag.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null, the corresponding
-     * attribute will not be rendered.
+     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null,
+     * the corresponding attribute will not be rendered.
      *
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -270,7 +294,7 @@ final class Html
      *
      * @param string $content the style content
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null, the
+     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null, the
      * corresponding attribute will not be rendered. See {@see renderTagAttributes()} for details on how attributes
      * are being rendered.
      *
@@ -288,9 +312,9 @@ final class Html
      *
      * @param string $content the script content
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null, the corresponding
-     * attribute will not be rendered. See {@see renderTagAttributes()} for details on how attributes are being
-     * rendered.
+     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null,
+     * the corresponding attribute will not be rendered. See {@see renderTagAttributes()} for details on how attributes
+     * are being rendered.
      *
      * @return string the generated script tag
      *
@@ -313,7 +337,7 @@ final class Html
      * - noscript: if set to true, `link` tag will be wrapped into `<noscript>` tags.
      *
      * The rest of the options will be rendered as the attributes of the resulting link tag. The values will be
-     * HTML-encoded using {@see encodeAttribute()}. If a value is null, the corresponding attribute
+     * HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null, the corresponding attribute
      * will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -353,8 +377,8 @@ final class Html
      *   versions of IE browsers.
      *
      * The rest of the options will be rendered as the attributes of the resulting script tag. The values will be
-     * HTML-encoded using {@see encodeAttribute()}. If a value is null, the corresponding attribute will not be rendered.
-     * See {@see renderTagAttributes()} for details on how attributes are being rendered.
+     * HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null, the corresponding attribute will
+     * not be rendered. See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
      * @return string the generated script tag.
      *
@@ -405,7 +429,7 @@ final class Html
      * ```
      *
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}.
+     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}.
      * If a value is null, the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -430,7 +454,7 @@ final class Html
      * @param string|null $email email address. If this is null, the first parameter (link body) will be treated
      * as the email address and used.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null,
+     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null,
      * the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -449,7 +473,7 @@ final class Html
      *
      * @param string $src the image URL. This parameter will be processed.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}.
+     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}.
      * If a value is null, the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -487,7 +511,7 @@ final class Html
      * @param string|null $for the ID of the HTML element that this label is associated with.
      * If this is null, the "for" attribute will not be generated.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null, the
+     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null, the
      * corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -508,7 +532,7 @@ final class Html
      * can pass in HTML code such as an image tag. If this is is coming from end users, you should consider
      * {@see encodeContent()} it to prevent XSS attacks.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes
-     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null, the
+     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null, the
      * corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -536,7 +560,7 @@ final class Html
      * can pass in HTML code such as an image tag. If this is is coming from end users, you should consider
      * {@see encodeContent()} it to prevent XSS attacks.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null,
+     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null,
      * the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -558,7 +582,7 @@ final class Html
      * can pass in HTML code such as an image tag. If this is is coming from end users, you should consider
      * {@see encodeContent()} it to prevent XSS attacks.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null,
+     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null,
      * the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -581,7 +605,7 @@ final class Html
      * @param string|bool|int|float|null|callable $value the value attribute. If it is null, the value attribute will
      * not be generated.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}.
+     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}.
      * If a value is null, the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -606,8 +630,8 @@ final class Html
      *
      * @param string $label the value attribute. If it is null, the value attribute will not be generated.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null, the corresponding
-     * attribute will not be rendered.
+     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null,
+     * the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
      * @return string the generated button tag
@@ -631,8 +655,8 @@ final class Html
      *
      * @param string $label the value attribute. If it is null, the value attribute will not be generated.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null, the corresponding
-     * attribute will not be rendered.
+     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null,
+     * the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
      * @return string the generated button tag
@@ -652,7 +676,7 @@ final class Html
      *
      * @param string $label the value attribute. If it is null, the value attribute will not be generated.
      * @param array $options the attributes of the button tag. The values will be HTML-encoded using
-     * {@see encodeAttribute()}. Attributes whose value is null will be ignored and not put in the tag returned.
+     * {@see encodeQuotedAttribute()}. Attributes whose value is null will be ignored and not put in the tag returned.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
      * @return string the generated button tag
@@ -673,7 +697,7 @@ final class Html
      * @param string $name the name attribute.
      * @param string|null $value the value attribute. If it is null, the value attribute will not be generated.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as
-     * the attributes of the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}.
+     * the attributes of the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}.
      * If a value is null, the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -693,7 +717,7 @@ final class Html
      * @param string|bool|int|float|null|callable $value the value attribute.
      * If it is null, the value attribute will not be generated.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null,
+     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null,
      * the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -712,7 +736,7 @@ final class Html
      * @param string $name the name attribute.
      * @param string|null $value the value attribute. If it is null, the value attribute will not be generated.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null,
+     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null,
      * the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -734,8 +758,8 @@ final class Html
      * @param string $name the name attribute.
      * @param string|null $value the value attribute. If it is null, the value attribute will not be generated.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as
-     * the attributes of the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value
-     * is null, the corresponding attribute will not be rendered.
+     * the attributes of the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}.
+     * If a value is null, the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
      * @return string the generated file input tag
@@ -753,7 +777,7 @@ final class Html
      * @param string $name the input name
      * @param string|null $value the input value. Note that it will be encoded using {@see encodeContent()}.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null,
+     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null,
      * the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      * The following special options are recognized:
@@ -829,7 +853,7 @@ final class Html
      *   else `<input> <label>Label</label>`
      *
      * The rest of the options will be rendered as the attributes of the resulting checkbox tag. The values will be
-     * HTML-encoded using {@see encodeAttribute()}. If a value is null, the corresponding attribute will not be
+     * HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null, the corresponding attribute will not be
      * rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -921,7 +945,7 @@ final class Html
      * - encode: bool, whether to encode option prompt and option value characters. Defaults to `true`.
      *
      * The rest of the options will be rendered as the attributes of the resulting tag. The values will be HTML-encoded
-     * using {@see encodeAttribute()}. If a value is null, the corresponding attribute will not be rendered.
+     * using {@see encodeQuotedAttribute()}. If a value is null, the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
      * @return string the generated drop-down list tag
@@ -985,7 +1009,7 @@ final class Html
      * - encode: bool, whether to encode option prompt and option value characters. Defaults to `true`.
      *
      * The rest of the options will be rendered as the attributes of the resulting tag. The values will be HTML-encoded
-     * using {@see encodeAttribute()}. If a value is null, the corresponding attribute will not be rendered.
+     * using {@see encodeQuotedAttribute()}. If a value is null, the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
      * @return string the generated list box tag.
@@ -1376,7 +1400,7 @@ final class Html
      * [boolean attributes](http://www.w3.org/TR/html5/infrastructure.html#boolean-attributes).
      *
      * Attributes whose values are null will not be rendered. The values of attributes will be HTML-encoded using
-     * {@see encodeAttribute()}.
+     * {@see encodeQuotedAttribute()}.
      *
      * The "data" attribute is specially handled when it is receiving an array value. In this case, the array will be
      * "expanded" and a list data attributes will be rendered. For example, if `'data' => ['id' => 1, 'name' => 'yii']`
@@ -1388,7 +1412,7 @@ final class Html
      * `data-params='{"id":1,"name":"yii"}' data-status="ok"`.
      *
      * @param array $attributes attributes to be rendered. The attribute values will be HTML-encoded using
-     * {@see encodeAttribute()}.
+     * {@see encodeQuotedAttribute()}.
      *
      * @return string the rendering result. If the attributes are not empty, they will be rendered into a string
      * with a leading white space (so that it can be directly appended to the tag name in a tag. If there is no
@@ -1422,24 +1446,24 @@ final class Html
                         if (is_array($v)) {
                             $html .= " $name-$n='" . Json::htmlEncode($v) . "'";
                         } else {
-                            $html .= " $name-$n=\"" . static::encodeAttribute($v) . '"';
+                            $html .= " $name-$n=\"" . static::encodeQuotedAttribute($v) . '"';
                         }
                     }
                 } elseif ($name === 'class') {
                     if (empty($value)) {
                         continue;
                     }
-                    $html .= " $name=\"" . static::encodeAttribute(implode(' ', $value)) . '"';
+                    $html .= " $name=\"" . static::encodeQuotedAttribute(implode(' ', $value)) . '"';
                 } elseif ($name === 'style') {
                     if (empty($value)) {
                         continue;
                     }
-                    $html .= " $name=\"" . static::encodeAttribute(static::cssStyleFromArray($value)) . '"';
+                    $html .= " $name=\"" . static::encodeQuotedAttribute(static::cssStyleFromArray($value)) . '"';
                 } else {
                     $html .= " $name='" . Json::htmlEncode($value) . "'";
                 }
             } elseif ($value !== null) {
-                $html .= " $name=\"" . static::encodeAttribute($value) . '"';
+                $html .= " $name=\"" . static::encodeQuotedAttribute($value) . '"';
             }
         }
 

--- a/src/Html.php
+++ b/src/Html.php
@@ -120,6 +120,8 @@ final class Html
      *
      * {@see decode()}
      * {@see http://www.php.net/manual/en/function.htmlspecialchars.php}
+     *
+     * @deprecated
      */
     public static function encode($content, $doubleEncode = true): string
     {
@@ -140,6 +142,8 @@ final class Html
      *
      * {@see encode()}
      * {@see http://www.php.net/manual/en/function.htmlspecialchars-decode.php}
+     *
+     * @deprecated
      */
     public static function decode(string $content): string
     {

--- a/src/Html.php
+++ b/src/Html.php
@@ -121,7 +121,7 @@ final class Html
      *
      * @see https://html.spec.whatwg.org/#data-state
      */
-    public static function encodeContent($content, $doubleEncode = true, string $encoding = 'UTF-8'): string
+    public static function encode($content, $doubleEncode = true, string $encoding = 'UTF-8'): string
     {
         return htmlspecialchars(
             (string)$content,
@@ -219,7 +219,7 @@ final class Html
      * @param string|bool|null $name the tag name. If $name is `null` or `false`, the corresponding content will be
      * rendered without any tag.
      * @param string $content the content to be enclosed between the start and end tags. It will not be HTML-encoded.
-     * If this is coming from end users, you should consider {@see encodeContent()} it to prevent XSS attacks.
+     * If this is coming from end users, you should consider {@see encode()} it to prevent XSS attacks.
      * @param array $options the HTML tag attributes (HTML options) in terms of name-value pairs. These will be
      * rendered as the attributes of the resulting tag. The values will be HTML-encoded using
      * {@see encodeQuotedAttribute()}. If a value is null, the corresponding attribute will not be rendered.
@@ -422,7 +422,7 @@ final class Html
      * Generates a hyperlink tag.
      *
      * @param string $text link body. It will NOT be HTML-encoded. Therefore you can pass in HTML code such as an image
-     * tag. If this is coming from end users, you should consider {@see encodeContent()} it to prevent XSS attacks.
+     * tag. If this is coming from end users, you should consider {@see encode()} it to prevent XSS attacks.
      * @param array|string|null $url the URL for the hyperlink tag. This parameter will be processed and will be used
      * for the "href" attribute of the tag. If this parameter is null, the "href" attribute will not
      * be generated.
@@ -455,7 +455,7 @@ final class Html
      * Generates a mailto hyperlink.
      *
      * @param string $text link body. It will NOT be HTML-encoded. Therefore you can pass in HTML code such as an image
-     * tag. If this is coming from end users, you should consider {@see encodeContent()} it to prevent XSS attacks.
+     * tag. If this is coming from end users, you should consider {@see encode()} it to prevent XSS attacks.
      * @param string|null $email email address. If this is null, the first parameter (link body) will be treated
      * as the email address and used.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
@@ -512,7 +512,7 @@ final class Html
      * Generates a label tag.
      *
      * @param string $content label text. It will NOT be HTML-encoded. Therefore you can pass in HTML code such as an
-     * image tag. If this is is coming from end users, you should {@see encodeContent()} it to prevent XSS attacks.
+     * image tag. If this is is coming from end users, you should {@see encode()} it to prevent XSS attacks.
      * @param string|null $for the ID of the HTML element that this label is associated with.
      * If this is null, the "for" attribute will not be generated.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
@@ -535,7 +535,7 @@ final class Html
      *
      * @param string $content the content enclosed within the button tag. It will NOT be HTML-encoded. Therefore you
      * can pass in HTML code such as an image tag. If this is is coming from end users, you should consider
-     * {@see encodeContent()} it to prevent XSS attacks.
+     * {@see encode()} it to prevent XSS attacks.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes
      * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null, the
      * corresponding attribute will not be rendered.
@@ -563,7 +563,7 @@ final class Html
      *
      * @param string $content the content enclosed within the button tag. It will NOT be HTML-encoded. Therefore you
      * can pass in HTML code such as an image tag. If this is is coming from end users, you should consider
-     * {@see encodeContent()} it to prevent XSS attacks.
+     * {@see encode()} it to prevent XSS attacks.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
      * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null,
      * the corresponding attribute will not be rendered.
@@ -585,7 +585,7 @@ final class Html
      *
      * @param string $content the content enclosed within the button tag. It will NOT be HTML-encoded. Therefore you
      * can pass in HTML code such as an image tag. If this is is coming from end users, you should consider
-     * {@see encodeContent()} it to prevent XSS attacks.
+     * {@see encode()} it to prevent XSS attacks.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
      * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null,
      * the corresponding attribute will not be rendered.
@@ -780,7 +780,7 @@ final class Html
      * Generates a text area input.
      *
      * @param string $name the input name
-     * @param string|null $value the input value. Note that it will be encoded using {@see encodeContent()}.
+     * @param string|null $value the input value. Note that it will be encoded using {@see encode()}.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
      * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null,
      * the corresponding attribute will not be rendered.
@@ -799,7 +799,7 @@ final class Html
         $options['name'] = $name;
         $doubleEncode = ArrayHelper::remove($options, 'doubleEncode', true);
 
-        return static::tag('textarea', static::encodeContent($value, $doubleEncode), $options);
+        return static::tag('textarea', static::encode($value, $doubleEncode), $options);
     }
 
     /**
@@ -848,7 +848,7 @@ final class Html
      *   a hidden input will be generated so that if the checkbox is not checked and is submitted, the value of this
      *   attribute will still be submitted to the server via the hidden input.
      * - label: string, a label displayed next to the checkbox. It will NOT be HTML-encoded. Therefore you can pass in
-     *   HTML code such as an image tag. If this is is coming from end users, you should {@see encodeContent()}
+     *   HTML code such as an image tag. If this is is coming from end users, you should {@see encode()}
      *   it to prevent XSS attacks.
      *   When this option is specified, the checkbox will be enclosed by a label tag.
      * - labelOptions: array, the HTML attributes for the label tag. Do not set this option unless you set the "label"
@@ -1116,7 +1116,7 @@ final class Html
             } else {
                 $lines[] = static::checkbox($name, $checked, array_merge([
                     'value' => $value,
-                    'label' => $encode ? static::encodeContent($label) : $label,
+                    'label' => $encode ? static::encode($label) : $label,
                 ], $itemOptions));
             }
             $index++;
@@ -1212,7 +1212,7 @@ final class Html
             } else {
                 $lines[] = static::radio($name, $checked, array_merge([
                     'value' => $value,
-                    'label' => $encode ? static::encodeContent($label) : $label,
+                    'label' => $encode ? static::encode($label) : $label,
                 ], $itemOptions));
             }
             $index++;
@@ -1268,7 +1268,7 @@ final class Html
             if ($formatter !== null) {
                 $results[] = $formatter($item, $index);
             } else {
-                $results[] = static::tag('li', $encode ? static::encodeContent($item) : $item, $itemOptions);
+                $results[] = static::tag('li', $encode ? static::encode($item) : $item, $itemOptions);
             }
         }
 
@@ -1352,7 +1352,7 @@ final class Html
                 $promptText = $tagOptions['prompt']['text'];
                 $promptOptions = array_merge($promptOptions, $tagOptions['prompt']['options']);
             }
-            $promptText = $encode ? static::encodeContent($promptText) : $promptText;
+            $promptText = $encode ? static::encode($promptText) : $promptText;
             if ($encodeSpaces) {
                 $promptText = str_replace(' ', '&nbsp;', $promptText);
             }
@@ -1387,7 +1387,7 @@ final class Html
                         ((!is_iterable($selection) && !strcmp((string)$key, $selection))
                             || (is_iterable($selection) && ArrayHelper::isIn((string)$key, $selection)));
                 }
-                $text = $encode ? static::encodeContent($value) : $value;
+                $text = $encode ? static::encode($value) : $value;
                 if ($encodeSpaces) {
                     $text = str_replace(' ', '&nbsp;', $text);
                 }

--- a/src/Html.php
+++ b/src/Html.php
@@ -147,15 +147,53 @@ final class Html
     }
 
     /**
+     * Encodes special characters in value into HTML entities for use as tag content.
+     * Encode symbols: &, <, >.
+     *
+     * @param mixed $content the content to be encoded
+     * @param bool $doubleEncode if already encoded entities should be encoded
+     * @param string $encoding the encoding to use, defaults to "UTF-8"
+     * @return string
+     */
+    public static function encodeContent($content, $doubleEncode = true, string $encoding = 'UTF-8'): string
+    {
+        return htmlspecialchars(
+            (string)$content,
+            ENT_NOQUOTES | ENT_SUBSTITUTE | ENT_HTML5,
+            $encoding,
+            $doubleEncode
+        );
+    }
+
+    /**
+     * Encodes special characters in value into HTML entities for use as attribute value of tag.
+     * Encode symbols: &, <, >, ", '.
+     *
+     * @param mixed $value the attribute value to be encoded
+     * @param bool $doubleEncode if already encoded entities should be encoded
+     * @param string $encoding the encoding to use, defaults to "UTF-8"
+     * @return string
+     */
+    public static function encodeAttribute($value, $doubleEncode = true, string $encoding = 'UTF-8'): string
+    {
+        return htmlspecialchars(
+            (string)$value,
+            ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5,
+            $encoding,
+            $doubleEncode
+        );
+    }
+
+    /**
      * Generates a complete HTML tag.
      *
      * @param string|bool|null $name the tag name. If $name is `null` or `false`, the corresponding content will be
      * rendered without any tag.
      * @param string $content the content to be enclosed between the start and end tags. It will not be HTML-encoded.
-     * If this is coming from end users, you should consider {@see encode()} it to prevent XSS attacks.
+     * If this is coming from end users, you should consider {@see encodeContent()} it to prevent XSS attacks.
      * @param array $options the HTML tag attributes (HTML options) in terms of name-value pairs. These will be
-     * rendered as the attributes of the resulting tag. The values will be HTML-encoded using {@see encode()}. If a
-     * value is null, the corresponding attribute will not be rendered.
+     * rendered as the attributes of the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}.
+     * If a value is null, the corresponding attribute will not be rendered.
      *
      * For example when using `['class' => 'my-class', 'target' => '_blank', 'value' => null]` it will result in the
      * HTML attributes rendered like this: `class="my-class" target="_blank"`.
@@ -186,7 +224,7 @@ final class Html
      * @param string|bool|null $name the tag name. If $name is `null` or `false`, the corresponding content will be
      * rendered without any tag.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encode()}. If a value is null, the corresponding
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null, the corresponding
      * attribute will not be rendered.
      *
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
@@ -232,9 +270,9 @@ final class Html
      *
      * @param string $content the style content
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encode()}. If a value is null, the corresponding
-     * attribute will not be rendered. See {@see renderTagAttributes()} for details on how attributes are being
-     * rendered.
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null, the
+     * corresponding attribute will not be rendered. See {@see renderTagAttributes()} for details on how attributes
+     * are being rendered.
      *
      * @return string the generated style tag
      *
@@ -250,7 +288,7 @@ final class Html
      *
      * @param string $content the script content
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encode()}. If a value is null, the corresponding
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null, the corresponding
      * attribute will not be rendered. See {@see renderTagAttributes()} for details on how attributes are being
      * rendered.
      *
@@ -275,7 +313,8 @@ final class Html
      * - noscript: if set to true, `link` tag will be wrapped into `<noscript>` tags.
      *
      * The rest of the options will be rendered as the attributes of the resulting link tag. The values will be
-     * HTML-encoded using {@see encode()}. If a value is null, the corresponding attribute will not be rendered.
+     * HTML-encoded using {@see encodeAttribute()}. If a value is null, the corresponding attribute
+     * will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
      * @return string the generated link tag.
@@ -314,7 +353,7 @@ final class Html
      *   versions of IE browsers.
      *
      * The rest of the options will be rendered as the attributes of the resulting script tag. The values will be
-     * HTML-encoded using {@see encode()}. If a value is null, the corresponding attribute will not be rendered.
+     * HTML-encoded using {@see encodeAttribute()}. If a value is null, the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
      * @return string the generated script tag.
@@ -354,7 +393,7 @@ final class Html
      * Generates a hyperlink tag.
      *
      * @param string $text link body. It will NOT be HTML-encoded. Therefore you can pass in HTML code such as an image
-     * tag. If this is coming from end users, you should consider {@see encode()} it to prevent XSS attacks.
+     * tag. If this is coming from end users, you should consider {@see encodeContent()} it to prevent XSS attacks.
      * @param array|string|null $url the URL for the hyperlink tag. This parameter will be processed and will be used
      * for the "href" attribute of the tag. If this parameter is null, the "href" attribute will not
      * be generated.
@@ -366,7 +405,7 @@ final class Html
      * ```
      *
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encode()}.
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}.
      * If a value is null, the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -387,12 +426,12 @@ final class Html
      * Generates a mailto hyperlink.
      *
      * @param string $text link body. It will NOT be HTML-encoded. Therefore you can pass in HTML code such as an image
-     * tag. If this is coming from end users, you should consider {@see encode()} it to prevent XSS attacks.
+     * tag. If this is coming from end users, you should consider {@see encodeContent()} it to prevent XSS attacks.
      * @param string|null $email email address. If this is null, the first parameter (link body) will be treated
      * as the email address and used.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encode()}. If a value is null, the corresponding
-     * attribute will not be rendered.
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null,
+     * the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
      * @return string the generated mailto link
@@ -410,7 +449,7 @@ final class Html
      *
      * @param string $src the image URL. This parameter will be processed.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encode()}.
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}.
      * If a value is null, the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -444,11 +483,11 @@ final class Html
      * Generates a label tag.
      *
      * @param string $content label text. It will NOT be HTML-encoded. Therefore you can pass in HTML code such as an
-     * image tag. If this is is coming from end users, you should {@see encode()} it to prevent XSS attacks.
+     * image tag. If this is is coming from end users, you should {@see encodeContent()} it to prevent XSS attacks.
      * @param string|null $for the ID of the HTML element that this label is associated with.
      * If this is null, the "for" attribute will not be generated.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encode()}. If a value is null, the
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null, the
      * corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -467,9 +506,9 @@ final class Html
      *
      * @param string $content the content enclosed within the button tag. It will NOT be HTML-encoded. Therefore you
      * can pass in HTML code such as an image tag. If this is is coming from end users, you should consider
-     * {@see encode()} it to prevent XSS attacks.
+     * {@see encodeContent()} it to prevent XSS attacks.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes
-     * the resulting tag. The values will be HTML-encoded using {@see encode()}. If a value is null, the
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null, the
      * corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -495,10 +534,10 @@ final class Html
      *
      * @param string $content the content enclosed within the button tag. It will NOT be HTML-encoded. Therefore you
      * can pass in HTML code such as an image tag. If this is is coming from end users, you should consider
-     * {@see encode()} it to prevent XSS attacks.
+     * {@see encodeContent()} it to prevent XSS attacks.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encode()}. If a value is null, the corresponding
-     * attribute will not be rendered.
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null,
+     * the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
      * @return string the generated submit button tag
@@ -517,10 +556,10 @@ final class Html
      *
      * @param string $content the content enclosed within the button tag. It will NOT be HTML-encoded. Therefore you
      * can pass in HTML code such as an image tag. If this is is coming from end users, you should consider
-     * {@see encode()} it to prevent XSS attacks.
+     * {@see encodeContent()} it to prevent XSS attacks.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encode()}. If a value is null, the corresponding
-     * attribute will not be rendered.
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null,
+     * the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
      * @return string the generated reset button tag
@@ -542,7 +581,7 @@ final class Html
      * @param string|bool|int|float|null|callable $value the value attribute. If it is null, the value attribute will
      * not be generated.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encode()}.
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}.
      * If a value is null, the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -567,7 +606,7 @@ final class Html
      *
      * @param string $label the value attribute. If it is null, the value attribute will not be generated.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encode()}. If a value is null, the corresponding
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null, the corresponding
      * attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -592,7 +631,7 @@ final class Html
      *
      * @param string $label the value attribute. If it is null, the value attribute will not be generated.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encode()}. If a value is null, the corresponding
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null, the corresponding
      * attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -612,8 +651,8 @@ final class Html
      * Generates a reset input button.
      *
      * @param string $label the value attribute. If it is null, the value attribute will not be generated.
-     * @param array $options the attributes of the button tag. The values will be HTML-encoded using {@see encode()}.
-     * Attributes whose value is null will be ignored and not put in the tag returned.
+     * @param array $options the attributes of the button tag. The values will be HTML-encoded using
+     * {@see encodeAttribute()}. Attributes whose value is null will be ignored and not put in the tag returned.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
      * @return string the generated button tag
@@ -634,8 +673,8 @@ final class Html
      * @param string $name the name attribute.
      * @param string|null $value the value attribute. If it is null, the value attribute will not be generated.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as
-     * the attributes of the resulting tag. The values will be HTML-encoded using {@see encode()}. If a value is null,
-     * the corresponding attribute will not be rendered.
+     * the attributes of the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}.
+     * If a value is null, the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
      * @return string the generated text input tag
@@ -654,8 +693,8 @@ final class Html
      * @param string|bool|int|float|null|callable $value the value attribute.
      * If it is null, the value attribute will not be generated.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encode()}. If a value is null, the corresponding
-     * attribute will not be rendered.
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null,
+     * the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
      * @return string the generated hidden input tag
@@ -673,8 +712,8 @@ final class Html
      * @param string $name the name attribute.
      * @param string|null $value the value attribute. If it is null, the value attribute will not be generated.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encode()}. If a value is null, the corresponding
-     * attribute will not be rendered.
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null,
+     * the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
      * @return string the generated password input tag
@@ -695,8 +734,8 @@ final class Html
      * @param string $name the name attribute.
      * @param string|null $value the value attribute. If it is null, the value attribute will not be generated.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as
-     * the attributes of the resulting tag. The values will be HTML-encoded using {@see encode()}. If a value is null,
-     * the corresponding attribute will not be rendered.
+     * the attributes of the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value
+     * is null, the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
      * @return string the generated file input tag
@@ -712,10 +751,10 @@ final class Html
      * Generates a text area input.
      *
      * @param string $name the input name
-     * @param string|null $value the input value. Note that it will be encoded using {@see encode()}.
+     * @param string|null $value the input value. Note that it will be encoded using {@see encodeContent()}.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encode()}. If a value is null, the corresponding
-     * attribute will not be rendered.
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null,
+     * the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      * The following special options are recognized:
      *
@@ -731,7 +770,7 @@ final class Html
         $options['name'] = $name;
         $doubleEncode = ArrayHelper::remove($options, 'doubleEncode', true);
 
-        return static::tag('textarea', static::encode($value, $doubleEncode), $options);
+        return static::tag('textarea', static::encodeContent($value, $doubleEncode), $options);
     }
 
     /**
@@ -780,8 +819,8 @@ final class Html
      *   a hidden input will be generated so that if the checkbox is not checked and is submitted, the value of this
      *   attribute will still be submitted to the server via the hidden input.
      * - label: string, a label displayed next to the checkbox. It will NOT be HTML-encoded. Therefore you can pass in
-     *   HTML code such as an image tag. If this is is coming from end users, you should {@see encode()} it to prevent
-     *   XSS attacks.
+     *   HTML code such as an image tag. If this is is coming from end users, you should {@see encodeContent()}
+     *   it to prevent XSS attacks.
      *   When this option is specified, the checkbox will be enclosed by a label tag.
      * - labelOptions: array, the HTML attributes for the label tag. Do not set this option unless you set the "label"
      *   option.
@@ -790,7 +829,8 @@ final class Html
      *   else `<input> <label>Label</label>`
      *
      * The rest of the options will be rendered as the attributes of the resulting checkbox tag. The values will be
-     * HTML-encoded using {@see encode()}. If a value is null, the corresponding attribute will not be rendered.
+     * HTML-encoded using {@see encodeAttribute()}. If a value is null, the corresponding attribute will not be
+     * rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
      * @return string the generated checkbox tag
@@ -881,7 +921,7 @@ final class Html
      * - encode: bool, whether to encode option prompt and option value characters. Defaults to `true`.
      *
      * The rest of the options will be rendered as the attributes of the resulting tag. The values will be HTML-encoded
-     * using {@see encode()}. If a value is null, the corresponding attribute will not be rendered.
+     * using {@see encodeAttribute()}. If a value is null, the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
      * @return string the generated drop-down list tag
@@ -945,7 +985,7 @@ final class Html
      * - encode: bool, whether to encode option prompt and option value characters. Defaults to `true`.
      *
      * The rest of the options will be rendered as the attributes of the resulting tag. The values will be HTML-encoded
-     * using {@see encode()}. If a value is null, the corresponding attribute will not be rendered.
+     * using {@see encodeAttribute()}. If a value is null, the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
      * @return string the generated list box tag.
@@ -1047,7 +1087,7 @@ final class Html
             } else {
                 $lines[] = static::checkbox($name, $checked, array_merge([
                     'value' => $value,
-                    'label' => $encode ? static::encode($label) : $label,
+                    'label' => $encode ? static::encodeContent($label) : $label,
                 ], $itemOptions));
             }
             $index++;
@@ -1143,7 +1183,7 @@ final class Html
             } else {
                 $lines[] = static::radio($name, $checked, array_merge([
                     'value' => $value,
-                    'label' => $encode ? static::encode($label) : $label,
+                    'label' => $encode ? static::encodeContent($label) : $label,
                 ], $itemOptions));
             }
             $index++;
@@ -1199,7 +1239,7 @@ final class Html
             if ($formatter !== null) {
                 $results[] = $formatter($item, $index);
             } else {
-                $results[] = static::tag('li', $encode ? static::encode($item) : $item, $itemOptions);
+                $results[] = static::tag('li', $encode ? static::encodeContent($item) : $item, $itemOptions);
             }
         }
 
@@ -1283,7 +1323,7 @@ final class Html
                 $promptText = $tagOptions['prompt']['text'];
                 $promptOptions = array_merge($promptOptions, $tagOptions['prompt']['options']);
             }
-            $promptText = $encode ? static::encode($promptText) : $promptText;
+            $promptText = $encode ? static::encodeContent($promptText) : $promptText;
             if ($encodeSpaces) {
                 $promptText = str_replace(' ', '&nbsp;', $promptText);
             }
@@ -1318,7 +1358,7 @@ final class Html
                         ((!is_iterable($selection) && !strcmp((string)$key, $selection))
                             || (is_iterable($selection) && ArrayHelper::isIn((string)$key, $selection)));
                 }
-                $text = $encode ? static::encode($value) : $value;
+                $text = $encode ? static::encodeContent($value) : $value;
                 if ($encodeSpaces) {
                     $text = str_replace(' ', '&nbsp;', $text);
                 }
@@ -1336,7 +1376,7 @@ final class Html
      * [boolean attributes](http://www.w3.org/TR/html5/infrastructure.html#boolean-attributes).
      *
      * Attributes whose values are null will not be rendered. The values of attributes will be HTML-encoded using
-     * {@see encode()}.
+     * {@see encodeAttribute()}.
      *
      * The "data" attribute is specially handled when it is receiving an array value. In this case, the array will be
      * "expanded" and a list data attributes will be rendered. For example, if `'data' => ['id' => 1, 'name' => 'yii']`
@@ -1348,7 +1388,7 @@ final class Html
      * `data-params='{"id":1,"name":"yii"}' data-status="ok"`.
      *
      * @param array $attributes attributes to be rendered. The attribute values will be HTML-encoded using
-     * {@see encode()}.
+     * {@see encodeAttribute()}.
      *
      * @return string the rendering result. If the attributes are not empty, they will be rendered into a string
      * with a leading white space (so that it can be directly appended to the tag name in a tag. If there is no
@@ -1382,24 +1422,24 @@ final class Html
                         if (is_array($v)) {
                             $html .= " $name-$n='" . Json::htmlEncode($v) . "'";
                         } else {
-                            $html .= " $name-$n=\"" . static::encode($v) . '"';
+                            $html .= " $name-$n=\"" . static::encodeAttribute($v) . '"';
                         }
                     }
                 } elseif ($name === 'class') {
                     if (empty($value)) {
                         continue;
                     }
-                    $html .= " $name=\"" . static::encode(implode(' ', $value)) . '"';
+                    $html .= " $name=\"" . static::encodeAttribute(implode(' ', $value)) . '"';
                 } elseif ($name === 'style') {
                     if (empty($value)) {
                         continue;
                     }
-                    $html .= " $name=\"" . static::encode(static::cssStyleFromArray($value)) . '"';
+                    $html .= " $name=\"" . static::encodeAttribute(static::cssStyleFromArray($value)) . '"';
                 } else {
                     $html .= " $name='" . Json::htmlEncode($value) . "'";
                 }
             } elseif ($value !== null) {
-                $html .= " $name=\"" . static::encode($value) . '"';
+                $html .= " $name=\"" . static::encodeAttribute($value) . '"';
             }
         }
 

--- a/src/Html.php
+++ b/src/Html.php
@@ -158,6 +158,8 @@ final class Html
      * @param bool $doubleEncode if already encoded entities should be encoded
      * @param string $encoding the encoding to use, defaults to "UTF-8"
      * @return string
+     *
+     * @see https://html.spec.whatwg.org/#data-state
      */
     public static function encodeContent($content, $doubleEncode = true, string $encoding = 'UTF-8'): string
     {
@@ -171,12 +173,16 @@ final class Html
 
     /**
      * Encodes special characters in value into HTML entities for use as attribute value of tag.
-     * Encode symbols: &, <, >, ", ', ` and space.
+     * Encode symbols: &, <, >, ", ', `, =, tab, space, U+000A (form feed), U+0000 (null).
      *
      * @param mixed $value the attribute value to be encoded
      * @param bool $doubleEncode if already encoded entities should be encoded
      * @param string $encoding the encoding to use, defaults to "UTF-8"
      * @return string
+     *
+     * @see https://html.spec.whatwg.org/#attribute-value-(unquoted)-state
+     * @see https://html.spec.whatwg.org/#attribute-value-(single-quoted)-state
+     * @see https://html.spec.whatwg.org/#attribute-value-(double-quoted)-state
      */
     public static function encodeAttribute($value, $doubleEncode = true, string $encoding = 'UTF-8'): string
     {
@@ -188,28 +194,40 @@ final class Html
         );
 
         return strtr($value, [
-            ' ' => '&#32;',
-            '`' => '&grave;',
+            "\t" => '&Tab;', // U+0009 CHARACTER TABULATION (tab)
+            "\n" => '&NewLine;', // U+000A LINE FEED (LF)
+            "\u{000c}" => '&#12;', // U+000C FORM FEED (FF)
+            "\u{0000}" => '&#0;', // U+0000 NULL
+            ' ' => '&#32;', // U+0020 SPACE
+            '=' => '&equals;', // U+003D EQUALS SIGN (=)
+            '`' => '&grave;', // U+0060 GRAVE ACCENT (`)
         ]);
     }
 
     /**
      * Encodes special characters in value into HTML entities for use as quoted attribute value of tag.
-     * Encode symbols: &, <, >, ", '.
+     * Encode symbols: &, <, >, ", ', U+0000 (null).
      *
      * @param mixed $value the attribute value to be encoded
      * @param bool $doubleEncode if already encoded entities should be encoded
      * @param string $encoding the encoding to use, defaults to "UTF-8"
      * @return string
+     *
+     * @see https://html.spec.whatwg.org/#attribute-value-(single-quoted)-state
+     * @see https://html.spec.whatwg.org/#attribute-value-(double-quoted)-state
      */
     public static function encodeQuotedAttribute($value, $doubleEncode = true, string $encoding = 'UTF-8'): string
     {
-        return htmlspecialchars(
+        $value = htmlspecialchars(
             (string)$value,
             ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5,
             $encoding,
             $doubleEncode
         );
+
+        return strtr($value, [
+            "\u{0000}" => '&#0;', // U+0000 NULL
+        ]);
     }
 
     /**

--- a/src/Html.php
+++ b/src/Html.php
@@ -111,8 +111,9 @@ final class Html
     }
 
     /**
-     * Encodes special characters in value into HTML entities for use as tag content.
-     * Encode characters: &, <, >.
+     * Encodes special characters into HTML entities for use as a tag content
+     * i.e. `<div>tag content</div>`.
+     * Characters encoded are: &, <, >.
      *
      * @param mixed $content the content to be encoded
      * @param bool $doubleEncode if already encoded entities should be encoded
@@ -132,8 +133,9 @@ final class Html
     }
 
     /**
-     * Encodes special characters in value into HTML entities for use as attribute value of tag.
-     * Encode characters: &, <, >, ", ', `, =, tab, space, U+000A (form feed), U+0000 (null).
+     * Encodes special characters into HTML entities for use as HTML tag unquoted attribute value
+     * i.e. `<input value=my-value>`.
+     * Characters encoded are: &, <, >, ", ', `, =, tab, space, U+000A (form feed), U+0000 (null).
      *
      * @param mixed $value the attribute value to be encoded
      * @param bool $doubleEncode if already encoded entities should be encoded
@@ -144,7 +146,7 @@ final class Html
      * @see https://html.spec.whatwg.org/#attribute-value-(single-quoted)-state
      * @see https://html.spec.whatwg.org/#attribute-value-(double-quoted)-state
      */
-    public static function encodeAttribute($value, $doubleEncode = true, string $encoding = 'UTF-8'): string
+    public static function encodeUnquotedAttribute($value, $doubleEncode = true, string $encoding = 'UTF-8'): string
     {
         $value = htmlspecialchars(
             (string)$value,
@@ -165,8 +167,9 @@ final class Html
     }
 
     /**
-     * Encodes special characters in value into HTML entities for use as quoted attribute value of tag.
-     * Encode characters: &, <, >, ", ', U+0000 (null).
+     * Encodes special characters into HTML entities for use as HTML tag quoted attribute value
+     * i.e. `<input value="my-value">`.
+     * Characters encoded are: &, <, >, ", ', U+0000 (null).
      *
      * @param mixed $value the attribute value to be encoded
      * @param bool $doubleEncode if already encoded entities should be encoded
@@ -176,7 +179,7 @@ final class Html
      * @see https://html.spec.whatwg.org/#attribute-value-(single-quoted)-state
      * @see https://html.spec.whatwg.org/#attribute-value-(double-quoted)-state
      */
-    public static function encodeQuotedAttribute($value, $doubleEncode = true, string $encoding = 'UTF-8'): string
+    public static function encodeAttribute($value, $doubleEncode = true, string $encoding = 'UTF-8'): string
     {
         $value = htmlspecialchars(
             (string)$value,
@@ -222,7 +225,7 @@ final class Html
      * If this is coming from end users, you should consider {@see encode()} it to prevent XSS attacks.
      * @param array $options the HTML tag attributes (HTML options) in terms of name-value pairs. These will be
      * rendered as the attributes of the resulting tag. The values will be HTML-encoded using
-     * {@see encodeQuotedAttribute()}. If a value is null, the corresponding attribute will not be rendered.
+     * {@see encodeAttribute()}. If a value is null, the corresponding attribute will not be rendered.
      *
      * For example when using `['class' => 'my-class', 'target' => '_blank', 'value' => null]` it will result in the
      * HTML attributes rendered like this: `class="my-class" target="_blank"`.
@@ -253,7 +256,7 @@ final class Html
      * @param string|bool|null $name the tag name. If $name is `null` or `false`, the corresponding content will be
      * rendered without any tag.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null,
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null,
      * the corresponding attribute will not be rendered.
      *
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
@@ -299,7 +302,7 @@ final class Html
      *
      * @param string $content the style content
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null, the
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null, the
      * corresponding attribute will not be rendered. See {@see renderTagAttributes()} for details on how attributes
      * are being rendered.
      *
@@ -317,7 +320,7 @@ final class Html
      *
      * @param string $content the script content
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null,
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null,
      * the corresponding attribute will not be rendered. See {@see renderTagAttributes()} for details on how attributes
      * are being rendered.
      *
@@ -342,7 +345,7 @@ final class Html
      * - noscript: if set to true, `link` tag will be wrapped into `<noscript>` tags.
      *
      * The rest of the options will be rendered as the attributes of the resulting link tag. The values will be
-     * HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null, the corresponding attribute
+     * HTML-encoded using {@see encodeAttribute()}. If a value is null, the corresponding attribute
      * will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -382,7 +385,7 @@ final class Html
      *   versions of IE browsers.
      *
      * The rest of the options will be rendered as the attributes of the resulting script tag. The values will be
-     * HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null, the corresponding attribute will
+     * HTML-encoded using {@see encodeAttribute()}. If a value is null, the corresponding attribute will
      * not be rendered. See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
      * @return string the generated script tag.
@@ -434,7 +437,7 @@ final class Html
      * ```
      *
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}.
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}.
      * If a value is null, the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -459,7 +462,7 @@ final class Html
      * @param string|null $email email address. If this is null, the first parameter (link body) will be treated
      * as the email address and used.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null,
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null,
      * the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -478,7 +481,7 @@ final class Html
      *
      * @param string $src the image URL. This parameter will be processed.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}.
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}.
      * If a value is null, the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -516,7 +519,7 @@ final class Html
      * @param string|null $for the ID of the HTML element that this label is associated with.
      * If this is null, the "for" attribute will not be generated.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null, the
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null, the
      * corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -537,7 +540,7 @@ final class Html
      * can pass in HTML code such as an image tag. If this is is coming from end users, you should consider
      * {@see encode()} it to prevent XSS attacks.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes
-     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null, the
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null, the
      * corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -565,7 +568,7 @@ final class Html
      * can pass in HTML code such as an image tag. If this is is coming from end users, you should consider
      * {@see encode()} it to prevent XSS attacks.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null,
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null,
      * the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -587,7 +590,7 @@ final class Html
      * can pass in HTML code such as an image tag. If this is is coming from end users, you should consider
      * {@see encode()} it to prevent XSS attacks.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null,
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null,
      * the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -610,7 +613,7 @@ final class Html
      * @param string|bool|int|float|null|callable $value the value attribute. If it is null, the value attribute will
      * not be generated.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}.
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}.
      * If a value is null, the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -635,7 +638,7 @@ final class Html
      *
      * @param string $label the value attribute. If it is null, the value attribute will not be generated.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null,
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null,
      * the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -660,7 +663,7 @@ final class Html
      *
      * @param string $label the value attribute. If it is null, the value attribute will not be generated.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null,
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null,
      * the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -681,7 +684,7 @@ final class Html
      *
      * @param string $label the value attribute. If it is null, the value attribute will not be generated.
      * @param array $options the attributes of the button tag. The values will be HTML-encoded using
-     * {@see encodeQuotedAttribute()}. Attributes whose value is null will be ignored and not put in the tag returned.
+     * {@see encodeAttribute()}. Attributes whose value is null will be ignored and not put in the tag returned.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
      * @return string the generated button tag
@@ -702,7 +705,7 @@ final class Html
      * @param string $name the name attribute.
      * @param string|null $value the value attribute. If it is null, the value attribute will not be generated.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as
-     * the attributes of the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}.
+     * the attributes of the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}.
      * If a value is null, the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -722,7 +725,7 @@ final class Html
      * @param string|bool|int|float|null|callable $value the value attribute.
      * If it is null, the value attribute will not be generated.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null,
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null,
      * the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -741,7 +744,7 @@ final class Html
      * @param string $name the name attribute.
      * @param string|null $value the value attribute. If it is null, the value attribute will not be generated.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null,
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null,
      * the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -763,7 +766,7 @@ final class Html
      * @param string $name the name attribute.
      * @param string|null $value the value attribute. If it is null, the value attribute will not be generated.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as
-     * the attributes of the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}.
+     * the attributes of the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}.
      * If a value is null, the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -782,7 +785,7 @@ final class Html
      * @param string $name the input name
      * @param string|null $value the input value. Note that it will be encoded using {@see encode()}.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
-     * the resulting tag. The values will be HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null,
+     * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null,
      * the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      * The following special options are recognized:
@@ -858,7 +861,7 @@ final class Html
      *   else `<input> <label>Label</label>`
      *
      * The rest of the options will be rendered as the attributes of the resulting checkbox tag. The values will be
-     * HTML-encoded using {@see encodeQuotedAttribute()}. If a value is null, the corresponding attribute will not be
+     * HTML-encoded using {@see encodeAttribute()}. If a value is null, the corresponding attribute will not be
      * rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
@@ -950,7 +953,7 @@ final class Html
      * - encode: bool, whether to encode option prompt and option value characters. Defaults to `true`.
      *
      * The rest of the options will be rendered as the attributes of the resulting tag. The values will be HTML-encoded
-     * using {@see encodeQuotedAttribute()}. If a value is null, the corresponding attribute will not be rendered.
+     * using {@see encodeAttribute()}. If a value is null, the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
      * @return string the generated drop-down list tag
@@ -1014,7 +1017,7 @@ final class Html
      * - encode: bool, whether to encode option prompt and option value characters. Defaults to `true`.
      *
      * The rest of the options will be rendered as the attributes of the resulting tag. The values will be HTML-encoded
-     * using {@see encodeQuotedAttribute()}. If a value is null, the corresponding attribute will not be rendered.
+     * using {@see encodeAttribute()}. If a value is null, the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
      * @return string the generated list box tag.
@@ -1405,7 +1408,7 @@ final class Html
      * [boolean attributes](http://www.w3.org/TR/html5/infrastructure.html#boolean-attributes).
      *
      * Attributes whose values are null will not be rendered. The values of attributes will be HTML-encoded using
-     * {@see encodeQuotedAttribute()}.
+     * {@see encodeAttribute()}.
      *
      * The "data" attribute is specially handled when it is receiving an array value. In this case, the array will be
      * "expanded" and a list data attributes will be rendered. For example, if `'data' => ['id' => 1, 'name' => 'yii']`
@@ -1417,7 +1420,7 @@ final class Html
      * `data-params='{"id":1,"name":"yii"}' data-status="ok"`.
      *
      * @param array $attributes attributes to be rendered. The attribute values will be HTML-encoded using
-     * {@see encodeQuotedAttribute()}.
+     * {@see encodeAttribute()}.
      *
      * @return string the rendering result. If the attributes are not empty, they will be rendered into a string
      * with a leading white space (so that it can be directly appended to the tag name in a tag. If there is no
@@ -1451,24 +1454,24 @@ final class Html
                         if (is_array($v)) {
                             $html .= " $name-$n='" . Json::htmlEncode($v) . "'";
                         } else {
-                            $html .= " $name-$n=\"" . static::encodeQuotedAttribute($v) . '"';
+                            $html .= " $name-$n=\"" . static::encodeAttribute($v) . '"';
                         }
                     }
                 } elseif ($name === 'class') {
                     if (empty($value)) {
                         continue;
                     }
-                    $html .= " $name=\"" . static::encodeQuotedAttribute(implode(' ', $value)) . '"';
+                    $html .= " $name=\"" . static::encodeAttribute(implode(' ', $value)) . '"';
                 } elseif ($name === 'style') {
                     if (empty($value)) {
                         continue;
                     }
-                    $html .= " $name=\"" . static::encodeQuotedAttribute(static::cssStyleFromArray($value)) . '"';
+                    $html .= " $name=\"" . static::encodeAttribute(static::cssStyleFromArray($value)) . '"';
                 } else {
                     $html .= " $name='" . Json::htmlEncode($value) . "'";
                 }
             } elseif ($value !== null) {
-                $html .= " $name=\"" . static::encodeQuotedAttribute($value) . '"';
+                $html .= " $name=\"" . static::encodeAttribute($value) . '"';
             }
         }
 

--- a/src/Html.php
+++ b/src/Html.php
@@ -111,46 +111,6 @@ final class Html
     }
 
     /**
-     * Encodes special characters into HTML entities.
-     *
-     * @param mixed $content the content to be encoded
-     * @param bool $doubleEncode if already encoded entities should be encoded
-     *
-     * @return string the encoded content
-     *
-     * {@see decode()}
-     * {@see http://www.php.net/manual/en/function.htmlspecialchars.php}
-     *
-     * @deprecated
-     */
-    public static function encode($content, $doubleEncode = true): string
-    {
-        return htmlspecialchars(
-            (string)$content,
-            ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5,
-            ini_get('default_charset'),
-            $doubleEncode
-        );
-    }
-
-    /**
-     * Decodes special HTML entities back to the corresponding characters. This is the opposite of {@see encode()}.
-     *
-     * @param string $content the content to be decoded
-     *
-     * @return string the decoded content
-     *
-     * {@see encode()}
-     * {@see http://www.php.net/manual/en/function.htmlspecialchars-decode.php}
-     *
-     * @deprecated
-     */
-    public static function decode(string $content): string
-    {
-        return htmlspecialchars_decode($content, ENT_QUOTES);
-    }
-
-    /**
      * Encodes special characters in value into HTML entities for use as tag content.
      * Encode characters: &, <, >.
      *

--- a/src/Html.php
+++ b/src/Html.php
@@ -194,8 +194,7 @@ final class Html
     }
 
     /**
-     * Escape special characters in value for use as string value in javascipt into tag script.
-     * For example:
+     * Escape special characters for use as JavaScript string value in a `<script` tag:
      *
      * ```
      * <script type="text/javascript">
@@ -206,7 +205,7 @@ final class Html
      * @param mixed $value
      * @return string
      */
-    public static function escapeJsStringValue($value): string
+    public static function escapeJavaScriptStringValue($value): string
     {
         return strtr((string)$value, [
             '/' => '\/',

--- a/tests/EncodeTest.php
+++ b/tests/EncodeTest.php
@@ -8,7 +8,7 @@ use Yiisoft\Html\Html;
 
 final class EncodeTest extends TestCase
 {
-    private function dataEncode(string $context): array
+    private function makeData(string $context): array
     {
         $items = [
             [
@@ -77,30 +77,30 @@ final class EncodeTest extends TestCase
         return $result;
     }
 
-    public function dataEncodeContent(): array
+    public function dataEncode(): array
     {
-        return $this->dataEncode('content');
+        return $this->makeData('content');
     }
 
     /**
-     * @dataProvider dataEncodeContent
+     * @dataProvider dataEncode
      *
      * @param mixed $content
      * @param string $expected
      */
-    public function testEncodeContent($content, string $expected): void
+    public function testEncode($content, string $expected): void
     {
-        $this->assertSame($expected, Html::encodeContent($content));
+        $this->assertSame($expected, Html::encode($content));
     }
 
-    public function testEncodeContentPreventDoubleEncode(): void
+    public function testEncodePreventDoubleEncode(): void
     {
-        $this->assertSame('Chip&amp;Dale &gt;', Html::encodeContent('Chip&amp;Dale >', false));
+        $this->assertSame('Chip&amp;Dale &gt;', Html::encode('Chip&amp;Dale >', false));
     }
 
     public function dataEncodeAttribute(): array
     {
-        return $this->dataEncode('attribute');
+        return $this->makeData('attribute');
     }
 
     /**
@@ -121,7 +121,7 @@ final class EncodeTest extends TestCase
 
     public function dataEncodeQuotedAttribute(): array
     {
-        return $this->dataEncode('quotedAttribute');
+        return $this->makeData('quotedAttribute');
     }
 
     /**

--- a/tests/EncodeTest.php
+++ b/tests/EncodeTest.php
@@ -12,11 +12,11 @@ final class EncodeTest extends TestCase
     {
         $items = [
             [
-                'value' => "a <>&\"'\x80\u{20bd}`",
+                'value' => "a \t=<>&\"'\x80\u{20bd}`\u{000a}\u{000c}\u{0000}",
                 'result' => [
-                    'content' => "a &lt;&gt;&amp;\"'�₽`",
-                    'attribute' => "a&#32;&lt;&gt;&amp;&quot;&apos;�₽&grave;",
-                    'quotedAttribute' => "a &lt;&gt;&amp;&quot;&apos;�₽`",
+                    'content' => "a \t=&lt;&gt;&amp;\"'�₽`\n\u{000c}\u{0000}",
+                    'attribute' => "a&#32;&Tab;&equals;&lt;&gt;&amp;&quot;&apos;�₽&grave;&NewLine;&#12;&#0;",
+                    'quotedAttribute' => "a \t=&lt;&gt;&amp;&quot;&apos;�₽`\n\u{000c}&#0;",
                 ],
             ],
             [
@@ -49,6 +49,14 @@ final class EncodeTest extends TestCase
                     'content' => 'Chip&amp;amp;Dale',
                     'attribute' => 'Chip&amp;amp;Dale',
                     'quotedAttribute' => 'Chip&amp;amp;Dale',
+                ],
+            ],
+            [
+                'value' => "\t\$x=24;",
+                'result' => [
+                    'content' => "\t\$x=24;",
+                    'attribute' => '&Tab;$x&equals;24;',
+                    'quotedAttribute' => "\t\$x=24;",
                 ],
             ],
             [

--- a/tests/EncodeTest.php
+++ b/tests/EncodeTest.php
@@ -31,6 +31,11 @@ final class EncodeTest extends TestCase
         $this->assertSame($expected, Html::encodeContent($content));
     }
 
+    public function testEncodeContentPreventDoubleEncode(): void
+    {
+        $this->assertSame('Chip&amp;Dale &gt;', Html::encodeContent('Chip&amp;Dale >', false));
+    }
+
     public function dataEncodeAttribute(): array
     {
         return [
@@ -54,6 +59,11 @@ final class EncodeTest extends TestCase
         $this->assertSame($expected, Html::encodeAttribute($content));
     }
 
+    public function testEncodeAttributePreventDoubleEncode(): void
+    {
+        $this->assertSame('Chip&amp;Dale&#32;&gt;', Html::encodeAttribute('Chip&amp;Dale >', false));
+    }
+
     public function dataEncodeQuotedAttribute(): array
     {
         return [
@@ -75,5 +85,10 @@ final class EncodeTest extends TestCase
     public function testEncodeQuotedAttribute($content, string $expected): void
     {
         $this->assertSame($expected, Html::encodeQuotedAttribute($content));
+    }
+
+    public function testEncodeQuotedAttributePreventDoubleEncode(): void
+    {
+        $this->assertSame('Chip&amp;Dale &gt;', Html::encodeQuotedAttribute('Chip&amp;Dale >', false));
     }
 }

--- a/tests/EncodeTest.php
+++ b/tests/EncodeTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests;
+
+use Yiisoft\Html\Html;
+
+final class EncodeTest extends TestCase
+{
+    public function dataEncodeContent(): array
+    {
+        return [
+            ["a <>&\"'\x80\u{20bd}`", "a &lt;&gt;&amp;\"'�₽`"],
+            ['<b>test</b>', '&lt;b&gt;test&lt;/b&gt;'],
+            ['"hello"', '"hello"'],
+            ["'hello'", "'hello'"],
+            ['Chip&amp;Dale', 'Chip&amp;amp;Dale'],
+        ];
+    }
+
+    /**
+     * @dataProvider dataEncodeContent
+     *
+     * @param mixed $content
+     * @param string $expected
+     */
+    public function testEncodeContent($content, string $expected): void
+    {
+        $this->assertSame($expected, Html::encodeContent($content));
+    }
+
+    public function dataEncodeAttribute(): array
+    {
+        return [
+            ["a <>&\"'\x80\u{20bd}`", "a &lt;&gt;&amp;&quot;&apos;�₽`"],
+            ['<b>test</b>', '&lt;b&gt;test&lt;/b&gt;'],
+            ['"hello"', '&quot;hello&quot;'],
+            ["'hello'", "&apos;hello&apos;"],
+            ['Chip&amp;Dale', 'Chip&amp;amp;Dale'],
+        ];
+    }
+
+    /**
+     * @dataProvider dataEncodeAttribute
+     *
+     * @param mixed $content
+     * @param string $expected
+     */
+    public function testEncodeAttribute($content, string $expected): void
+    {
+        $this->assertSame($expected, Html::encodeAttribute($content));
+    }
+}

--- a/tests/EncodeTest.php
+++ b/tests/EncodeTest.php
@@ -14,8 +14,9 @@ final class EncodeTest extends TestCase
             ["a <>&\"'\x80\u{20bd}`", "a &lt;&gt;&amp;\"'�₽`"],
             ['<b>test</b>', '&lt;b&gt;test&lt;/b&gt;'],
             ['"hello"', '"hello"'],
-            ["'hello'", "'hello'"],
+            ["'hello world'", "'hello world'"],
             ['Chip&amp;Dale', 'Chip&amp;amp;Dale'],
+            [36.6, '36.6'],
         ];
     }
 
@@ -33,11 +34,12 @@ final class EncodeTest extends TestCase
     public function dataEncodeAttribute(): array
     {
         return [
-            ["a <>&\"'\x80\u{20bd}`", "a &lt;&gt;&amp;&quot;&apos;�₽`"],
+            ["a <>&\"'\x80\u{20bd}`", "a&#32;&lt;&gt;&amp;&quot;&apos;�₽&grave;"],
             ['<b>test</b>', '&lt;b&gt;test&lt;/b&gt;'],
             ['"hello"', '&quot;hello&quot;'],
-            ["'hello'", "&apos;hello&apos;"],
+            ["'hello world'", "&apos;hello&#32;world&apos;"],
             ['Chip&amp;Dale', 'Chip&amp;amp;Dale'],
+            [36.6, '36.6'],
         ];
     }
 
@@ -50,5 +52,28 @@ final class EncodeTest extends TestCase
     public function testEncodeAttribute($content, string $expected): void
     {
         $this->assertSame($expected, Html::encodeAttribute($content));
+    }
+
+    public function dataEncodeQuotedAttribute(): array
+    {
+        return [
+            ["a <>&\"'\x80\u{20bd}`", "a &lt;&gt;&amp;&quot;&apos;�₽`"],
+            ['<b>test</b>', '&lt;b&gt;test&lt;/b&gt;'],
+            ['"hello"', '&quot;hello&quot;'],
+            ["'hello world'", "&apos;hello world&apos;"],
+            ['Chip&amp;Dale', 'Chip&amp;amp;Dale'],
+            [36.6, '36.6'],
+        ];
+    }
+
+    /**
+     * @dataProvider dataEncodeQuotedAttribute
+     *
+     * @param mixed $content
+     * @param string $expected
+     */
+    public function testEncodeQuotedAttribute($content, string $expected): void
+    {
+        $this->assertSame($expected, Html::encodeQuotedAttribute($content));
     }
 }

--- a/tests/EncodeTest.php
+++ b/tests/EncodeTest.php
@@ -98,9 +98,30 @@ final class EncodeTest extends TestCase
         $this->assertSame('Chip&amp;Dale &gt;', Html::encode('Chip&amp;Dale >', false));
     }
 
-    public function dataEncodeAttribute(): array
+    public function dataEncodeUnquotedAttribute(): array
     {
         return $this->makeData('attribute');
+    }
+
+    /**
+     * @dataProvider dataEncodeUnquotedAttribute
+     *
+     * @param mixed $content
+     * @param string $expected
+     */
+    public function testEncodeUnquotedAttribute($content, string $expected): void
+    {
+        $this->assertSame($expected, Html::encodeUnquotedAttribute($content));
+    }
+
+    public function testEncodeUnquotedAttributePreventDoubleEncode(): void
+    {
+        $this->assertSame('Chip&amp;Dale&#32;&gt;', Html::encodeUnquotedAttribute('Chip&amp;Dale >', false));
+    }
+
+    public function dataEncodeAttribute(): array
+    {
+        return $this->makeData('quotedAttribute');
     }
 
     /**
@@ -116,27 +137,6 @@ final class EncodeTest extends TestCase
 
     public function testEncodeAttributePreventDoubleEncode(): void
     {
-        $this->assertSame('Chip&amp;Dale&#32;&gt;', Html::encodeAttribute('Chip&amp;Dale >', false));
-    }
-
-    public function dataEncodeQuotedAttribute(): array
-    {
-        return $this->makeData('quotedAttribute');
-    }
-
-    /**
-     * @dataProvider dataEncodeQuotedAttribute
-     *
-     * @param mixed $content
-     * @param string $expected
-     */
-    public function testEncodeQuotedAttribute($content, string $expected): void
-    {
-        $this->assertSame($expected, Html::encodeQuotedAttribute($content));
-    }
-
-    public function testEncodeQuotedAttributePreventDoubleEncode(): void
-    {
-        $this->assertSame('Chip&amp;Dale &gt;', Html::encodeQuotedAttribute('Chip&amp;Dale >', false));
+        $this->assertSame('Chip&amp;Dale &gt;', Html::encodeAttribute('Chip&amp;Dale >', false));
     }
 }

--- a/tests/EncodeTest.php
+++ b/tests/EncodeTest.php
@@ -8,16 +8,70 @@ use Yiisoft\Html\Html;
 
 final class EncodeTest extends TestCase
 {
+    private function dataEncode(string $context): array
+    {
+        $items = [
+            [
+                'value' => "a <>&\"'\x80\u{20bd}`",
+                'result' => [
+                    'content' => "a &lt;&gt;&amp;\"'�₽`",
+                    'attribute' => "a&#32;&lt;&gt;&amp;&quot;&apos;�₽&grave;",
+                    'quotedAttribute' => "a &lt;&gt;&amp;&quot;&apos;�₽`",
+                ],
+            ],
+            [
+                'value' => '<b>test</b>',
+                'result' => [
+                    'content' => '&lt;b&gt;test&lt;/b&gt;',
+                    'attribute' => '&lt;b&gt;test&lt;/b&gt;',
+                    'quotedAttribute' => '&lt;b&gt;test&lt;/b&gt;',
+                ],
+            ],
+            [
+                'value' => '"hello"',
+                'result' => [
+                    'content' => '"hello"',
+                    'attribute' => '&quot;hello&quot;',
+                    'quotedAttribute' => '&quot;hello&quot;',
+                ],
+            ],
+            [
+                'value' => "'hello world'",
+                'result' => [
+                    'content' => "'hello world'",
+                    'attribute' => "&apos;hello&#32;world&apos;",
+                    'quotedAttribute' => "&apos;hello world&apos;",
+                ],
+            ],
+            [
+                'value' => 'Chip&amp;Dale',
+                'result' => [
+                    'content' => 'Chip&amp;amp;Dale',
+                    'attribute' => 'Chip&amp;amp;Dale',
+                    'quotedAttribute' => 'Chip&amp;amp;Dale',
+                ],
+            ],
+            [
+                'value' => 36.6,
+                'result' => [
+                    'content' => '36.6',
+                    'attribute' => '36.6',
+                    'quotedAttribute' => '36.6',
+                ],
+            ],
+        ];
+
+        $result = [];
+        foreach ($items as $item) {
+            $result[] = [$item['value'], $item['result'][$context]];
+        }
+
+        return $result;
+    }
+
     public function dataEncodeContent(): array
     {
-        return [
-            ["a <>&\"'\x80\u{20bd}`", "a &lt;&gt;&amp;\"'�₽`"],
-            ['<b>test</b>', '&lt;b&gt;test&lt;/b&gt;'],
-            ['"hello"', '"hello"'],
-            ["'hello world'", "'hello world'"],
-            ['Chip&amp;Dale', 'Chip&amp;amp;Dale'],
-            [36.6, '36.6'],
-        ];
+        return $this->dataEncode('content');
     }
 
     /**
@@ -38,14 +92,7 @@ final class EncodeTest extends TestCase
 
     public function dataEncodeAttribute(): array
     {
-        return [
-            ["a <>&\"'\x80\u{20bd}`", "a&#32;&lt;&gt;&amp;&quot;&apos;�₽&grave;"],
-            ['<b>test</b>', '&lt;b&gt;test&lt;/b&gt;'],
-            ['"hello"', '&quot;hello&quot;'],
-            ["'hello world'", "&apos;hello&#32;world&apos;"],
-            ['Chip&amp;Dale', 'Chip&amp;amp;Dale'],
-            [36.6, '36.6'],
-        ];
+        return $this->dataEncode('attribute');
     }
 
     /**
@@ -66,14 +113,7 @@ final class EncodeTest extends TestCase
 
     public function dataEncodeQuotedAttribute(): array
     {
-        return [
-            ["a <>&\"'\x80\u{20bd}`", "a &lt;&gt;&amp;&quot;&apos;�₽`"],
-            ['<b>test</b>', '&lt;b&gt;test&lt;/b&gt;'],
-            ['"hello"', '&quot;hello&quot;'],
-            ["'hello world'", "&apos;hello world&apos;"],
-            ['Chip&amp;Dale', 'Chip&amp;amp;Dale'],
-            [36.6, '36.6'],
-        ];
+        return $this->dataEncode('quotedAttribute');
     }
 
     /**

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -33,20 +33,6 @@ final class HtmlTest extends TestCase
         $this->assertSame('i1241', Html::generateId());
     }
 
-    public function testEncode(): void
-    {
-        $this->assertSame('a&lt;&gt;&amp;&quot;&apos;�', Html::encode("a<>&\"'\x80"));
-        $this->assertSame('Sam &amp; Dark', Html::encode('Sam & Dark'));
-        $this->assertSame('Test &amp;amp;', Html::encode('Test &amp;'));
-        $this->assertSame('36.6', Html::encode(36.6));
-        $this->assertSame('Test &amp;', Html::encode('Test &amp;', false));
-    }
-
-    public function testDecode(): void
-    {
-        $this->assertSame("a<>&\"'", Html::decode('a&lt;&gt;&amp;&quot;&#039;'));
-    }
-
     public function dataEscapeJsStringValue(): array
     {
         return [

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -47,6 +47,28 @@ final class HtmlTest extends TestCase
         $this->assertSame("a<>&\"'", Html::decode('a&lt;&gt;&amp;&quot;&#039;'));
     }
 
+    public function dataEscapeJsStringValue(): array
+    {
+        return [
+            ['</script>', '<\/script>'],
+            ['"double" quotes', '\"double\" quotes'],
+            ["'single' quotes", "\'single\' quotes"],
+            ['slashes //\\', 'slashes \/\/\\\\'],
+            [36.6, '36.6'],
+        ];
+    }
+
+    /**
+     * @dataProvider dataEscapeJsStringValue
+     *
+     * @param mixed $value
+     * @param string $expected
+     */
+    public function testEscapeJsStringValue($value, string $expected): void
+    {
+        $this->assertSame($expected, Html::escapeJsStringValue($value));
+    }
+
     public function testTag(): void
     {
         $this->assertSame('<br>', Html::tag('br'));

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -33,7 +33,7 @@ final class HtmlTest extends TestCase
         $this->assertSame('i1241', Html::generateId());
     }
 
-    public function dataEscapeJsStringValue(): array
+    public function dataEscapeJavaScriptStringValue(): array
     {
         return [
             ['</script>', '<\/script>'],
@@ -45,14 +45,14 @@ final class HtmlTest extends TestCase
     }
 
     /**
-     * @dataProvider dataEscapeJsStringValue
+     * @dataProvider dataEscapeJavaScriptStringValue
      *
      * @param mixed $value
      * @param string $expected
      */
-    public function testEscapeJsStringValue($value, string $expected): void
+    public function testEscapeJavaScriptStringValue($value, string $expected): void
     {
-        $this->assertSame($expected, Html::escapeJsStringValue($value));
+        $this->assertSame($expected, Html::escapeJavaScriptStringValue($value));
     }
 
     public function testTag(): void

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -38,6 +38,7 @@ final class HtmlTest extends TestCase
         $this->assertSame('a&lt;&gt;&amp;&quot;&apos;�', Html::encode("a<>&\"'\x80"));
         $this->assertSame('Sam &amp; Dark', Html::encode('Sam & Dark'));
         $this->assertSame('Test &amp;amp;', Html::encode('Test &amp;'));
+        $this->assertSame('36.6', Html::encode(36.6));
         $this->assertSame('Test &amp;', Html::encode('Test &amp;', false));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | #26

Added methods:

- `encodeAttribute`
- `encodeQuotedAttribute`
- `escapeJsStringValue`

Modify methods:

- `encode`

Removed methods:

- `decode`