### PR TITLE
Add Html::div(), Html::span() and Html::p().

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ Overall the helper has the following method groups.
 
 ### Generating base tags
 
+- div
+- span
+- p
 - ul
 - ol
 - img

--- a/src/Html.php
+++ b/src/Html.php
@@ -1225,6 +1225,48 @@ final class Html
     }
 
     /**
+     * Generates a div tag. Based on {@see Html::tag()}.
+     *
+     * @param string $content
+     * @param array $options
+     * @return string
+     *
+     * @throws JsonException
+     */
+    public static function div(string $content = '', array $options = []): string
+    {
+        return static::tag('div', $content, $options);
+    }
+
+    /**
+     * Generates a span tag. Based on {@see Html::tag()}.
+     *
+     * @param string $content
+     * @param array $options
+     * @return string
+     *
+     * @throws JsonException
+     */
+    public static function span(string $content = '', array $options = []): string
+    {
+        return static::tag('span', $content, $options);
+    }
+
+    /**
+     * Generates a paragraph tag. Based on {@see Html::tag()}.
+     *
+     * @param string $content
+     * @param array $options
+     * @return string
+     *
+     * @throws JsonException
+     */
+    public static function p(string $content = '', array $options = []): string
+    {
+        return static::tag('p', $content, $options);
+    }
+
+    /**
      * Generates an unordered list.
      *
      * @param array|Traversable $items the items for generating the list. Each item generates a single list item. Note

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -833,6 +833,21 @@ EOD;
         ));
     }
 
+    public function testDiv(): void
+    {
+        $this->assertSame('<div class="red">hello</div>', Html::div('hello', ['class' => 'red']));
+    }
+
+    public function testSpan(): void
+    {
+        $this->assertSame('<span class="red">hello</span>', Html::span('hello', ['class' => 'red']));
+    }
+
+    public function testP(): void
+    {
+        $this->assertSame('<p class="red">hello</p>', Html::p('hello', ['class' => 'red']));
+    }
+
     public function testUl(): void
     {
         $data = [1, 'abc', '<>'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -

Added methods for generate often used tags: `div`, `span` and `p`.
