### PR TITLE
Fix error in Html::renderSelectOptions when use "encode" as key in items array.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.4",
-        "roave/infection-static-analysis-plugin": "^1.5",
+        "roave/infection-static-analysis-plugin": "^1.6",
         "spatie/phpunit-watcher": "^1.23",
         "vimeo/psalm": "^4.2"
     },

--- a/src/Html.php
+++ b/src/Html.php
@@ -1417,8 +1417,6 @@ final class Html
         $options = $tagOptions['options'] ?? [];
         $groups = $tagOptions['groups'] ?? [];
         unset($tagOptions['prompt'], $tagOptions['options'], $tagOptions['groups']);
-        $options['encodeSpaces'] = ArrayHelper::getValue($options, 'encodeSpaces', $encodeSpaces);
-        $options['encode'] = ArrayHelper::getValue($options, 'encode', $encode);
 
         foreach ($items as $key => $value) {
             if (is_array($value)) {

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -1015,6 +1015,17 @@ EOD;
             ],
         ];
         $this->assertSameWithoutLE($expected, Html::renderSelectOptions(1, $data, $attributes));
+
+        $expected = <<<'EOD'
+<option value="encode">1</option>
+<option value="encodeSpaces">2</option>
+EOD;
+        $data = ['encode' => 1, 'encodeSpaces' => 2];
+        $attributes = [
+            'encode' => true,
+            'encodeSpaces' => false,
+        ];
+        $this->assertSameWithoutLE($expected, Html::renderSelectOptions(null, $data, $attributes));
     }
 
     public function testRenderAttributes(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #44 

Seems equal bug has in yii2...
