### PR TITLE
In Html::renderSelectOptions() pass 3 argument not by reference  + Adopt psalm.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
         "yiisoft/json": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.4",
+        "phpunit/phpunit": "^9.5",
         "roave/infection-static-analysis-plugin": "^1.6",
         "spatie/phpunit-watcher": "^1.23",
-        "vimeo/psalm": "^4.2"
+        "vimeo/psalm": "^4.3"
     },
     "autoload": {
         "psr-4": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    errorLevel="2"
+    errorLevel="1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    errorLevel="6"
-    resolveFromConfigFile="true"
+    errorLevel="2"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"

--- a/src/Html.php
+++ b/src/Html.php
@@ -1163,7 +1163,7 @@ final class Html
      * is an array.
      *
      * @param string $name the name attribute of each checkbox.
-     * @param array|Traversable|string|int|float|bool|null $selection the selected value(s). String for single or array
+     * @param array|bool|float|int|string|Traversable|null $selection the selected value(s). String for single or array
      * for multiple selection(s).
      * @param array $items the data item used to generate the checkboxes. The array keys are the checkbox values, while
      * the array values are the corresponding labels.
@@ -1273,7 +1273,7 @@ final class Html
      * A radio button list is like a checkbox list, except that it only allows single selection.
      *
      * @param string $name the name attribute of each radio button.
-     * @param array|Traversable|string|int|float|bool|null $selection the selected value(s). String for single or array
+     * @param array|bool|float|int|string|Traversable|null $selection the selected value(s). String for single or array
      * for multiple selection(s).
      * @param array $items the data item used to generate the radio buttons. The array keys are the radio button
      * values, while the array values are the corresponding labels.
@@ -1529,7 +1529,7 @@ final class Html
     /**
      * Renders the option tags that can be used by {@see dropDownList()} and {@see listBox()}.
      *
-     * @param array|Traversable|string|int|float|bool|null $selection the selected value(s). String for single or array
+     * @param array|bool|float|int|string|Traversable|null $selection the selected value(s). String for single or array
      * for multiple selection(s).
      * @param array $items the option data items. The array keys are option values, and the array values are the
      * corresponding option labels. The array can also be nested (i.e. some array values are arrays too). For each
@@ -1557,7 +1557,7 @@ final class Html
     }
 
     /**
-     * @param array|Traversable|string|int|float|bool|null $selection
+     * @param array|bool|float|int|string|Traversable|null $selection
      * @param array $items
      * @param array $tagOptions
      *

--- a/src/Html.php
+++ b/src/Html.php
@@ -1149,7 +1149,8 @@ final class Html
      * is an array.
      *
      * @param string $name the name attribute of each checkbox.
-     * @param array|string|null $selection the selected value(s). String for single or array for multiple selection(s).
+     * @param array|Traversable|string|int|float|bool|null $selection the selected value(s). String for single or array
+     * for multiple selection(s).
      * @param array $items the data item used to generate the checkboxes. The array keys are the checkbox values, while
      * the array values are the corresponding labels.
      * @param array $options options (name => config) for the checkbox list container tag. The following options are
@@ -1176,7 +1177,7 @@ final class Html
      *
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
-     * @psalm-param iterable<array-key, string>|string|int|float|\Stringable|bool|null $selection
+     * @psalm-param iterable<array-key, string>|string|\Stringable|int|float|bool|null $selection
      * @psalm-param array<array-key, string> $items
      * @psalm-param InputHtmlOptions&array{
      *   item?: Closure(int, string, string, bool, mixed):string|null,
@@ -1196,7 +1197,7 @@ final class Html
         $name = self::getArrayableName($name);
 
         if (is_iterable($selection)) {
-            $selection = array_map('strval', (array)$selection);
+            $selection = array_map('strval', is_array($selection) ? $selection : iterator_to_array($selection));
         } elseif ($selection !== null) {
             $selection = (string)$selection;
         }
@@ -1258,7 +1259,8 @@ final class Html
      * A radio button list is like a checkbox list, except that it only allows single selection.
      *
      * @param string $name the name attribute of each radio button.
-     * @param array|string|null $selection the selected value(s). String for single or array for multiple selection(s).
+     * @param array|Traversable|string|int|float|bool|null $selection the selected value(s). String for single or array
+     * for multiple selection(s).
      * @param array $items the data item used to generate the radio buttons. The array keys are the radio button
      * values, while the array values are the corresponding labels.
      * @param array $options options (name => config) for the radio button list container tag. The following options
@@ -1285,7 +1287,7 @@ final class Html
      *
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
-     * @psalm-param iterable<array-key, string>|string|int|float|\Stringable|bool|null $selection
+     * @psalm-param iterable<array-key, string>|string|\Stringable|int|float|bool|null $selection
      * @psalm-param array<array-key, string> $items
      * @psalm-param InputHtmlOptions&array{
      *   item?: Closure(int, string, string, bool, mixed):string|null,
@@ -1303,7 +1305,7 @@ final class Html
     public static function radioList(string $name, $selection = null, array $items = [], array $options = []): string
     {
         if (is_iterable($selection)) {
-            $selection = array_map('strval', (array)$selection);
+            $selection = array_map('strval', is_array($selection) ? $selection : iterator_to_array($selection));
         } elseif ($selection !== null) {
             $selection = (string)$selection;
         }
@@ -1513,7 +1515,7 @@ final class Html
     /**
      * Renders the option tags that can be used by {@see dropDownList()} and {@see listBox()}.
      *
-     * @param iterable|string|null $selection the selected value(s). String for single or array
+     * @param array|Traversable|string|int|float|bool|null $selection the selected value(s). String for single or array
      * for multiple selection(s).
      * @param array $items the option data items. The array keys are option values, and the array values are the
      * corresponding option labels. The array can also be nested (i.e. some array values are arrays too). For each
@@ -1540,11 +1542,11 @@ final class Html
     }
 
     /**
-     * @param $selection
+     * @param array|Traversable|string|int|float|bool|null $selection
      * @param array $items
      * @param array $tagOptions
      *
-     * @psalm-param iterable<array-key, string>|string|int|float|\Stringable|bool|null $selection
+     * @psalm-param iterable<array-key, string>|string|\Stringable|int|float|bool|null $selection
      * @psalm-param array<array-key, array|string> $items
      *
      * @throws JsonException
@@ -1554,7 +1556,7 @@ final class Html
     private static function renderSelectOptionTags($selection, array $items, array &$tagOptions): string
     {
         if (is_iterable($selection)) {
-            $selection = array_map('strval', (array)$selection);
+            $selection = array_map('strval', is_array($selection) ? $selection : iterator_to_array($selection));
         } elseif ($selection !== null) {
             $selection = (string)$selection;
         }
@@ -1636,6 +1638,8 @@ final class Html
      * Additionally `'data' => ['params' => ['id' => 1, 'name' => 'yii'], 'status' => 'ok']` will be rendered as:
      * `data-params='{"id":1,"name":"yii"}' data-status="ok"`.
      *
+     * @see addCssClass()
+     *
      * @param array $attributes attributes to be rendered. The attribute values will be HTML-encoded using
      * {@see encodeAttribute()}.
      *
@@ -1646,8 +1650,6 @@ final class Html
      * @return string the rendering result. If the attributes are not empty, they will be rendered into a string
      * with a leading white space (so that it can be directly appended to the tag name in a tag. If there is no
      * attribute, an empty string will be returned.
-     *
-     * @see addCssClass()
      */
     public static function renderTagAttributes(array $attributes): string
     {

--- a/src/Html.php
+++ b/src/Html.php
@@ -1536,7 +1536,7 @@ final class Html
      */
     public static function renderSelectOptions($selection, array $items, array $tagOptions = []): string
     {
-        return static::renderSelectOptionTags($selection, $items, $tagOptions);
+        return self::renderSelectOptionTags($selection, $items, $tagOptions);
     }
 
     /**
@@ -1547,9 +1547,9 @@ final class Html
      * @psalm-param iterable<array-key, string>|string|int|float|\Stringable|bool|null $selection
      * @psalm-param array<array-key, array|string> $items
      *
-     * @return string
-     *
      * @throws JsonException
+     *
+     * @return string
      */
     private static function renderSelectOptionTags($selection, array $items, array &$tagOptions): string
     {
@@ -1763,7 +1763,7 @@ final class Html
      * Removes a CSS class from the specified options.
      *
      * @param array $options the options to be modified.
-     * @param string[]|string $class the CSS class(es) to be removed
+     * @param string|string[] $class the CSS class(es) to be removed
      *
      * @see addCssClass()
      */
@@ -1841,7 +1841,7 @@ final class Html
      * ```
      *
      * @param array $options the HTML options to be modified.
-     * @param string[]|string $properties the CSS properties to be removed. You may use a string if you are removing a
+     * @param string|string[] $properties the CSS properties to be removed. You may use a string if you are removing a
      * single property.
      *
      * @psalm-param HtmlOptions $options

--- a/src/Html.php
+++ b/src/Html.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace Yiisoft\Html;
 
 use Closure;
-use function in_array;
 use InvalidArgumentException;
-use function is_array;
-use function is_bool;
-use function is_int;
-
 use JsonException;
 use Traversable;
 use Yiisoft\Arrays\ArrayHelper;
 use Yiisoft\Json\Json;
+
+use function in_array;
+use function is_array;
+use function is_bool;
+use function is_int;
 
 /**
  * Html provides a set of static methods for generating commonly used HTML tags.
@@ -1380,6 +1380,8 @@ final class Html
      * @param string $content
      * @param array $options
      *
+     * @psalm-param HtmlOptions|array<empty, empty> $options
+     *
      * @throws JsonException
      *
      * @return string
@@ -1395,6 +1397,8 @@ final class Html
      * @param string $content
      * @param array $options
      *
+     * @psalm-param HtmlOptions|array<empty, empty> $options
+     *
      * @throws JsonException
      *
      * @return string
@@ -1409,6 +1413,8 @@ final class Html
      *
      * @param string $content
      * @param array $options
+     *
+     * @psalm-param HtmlOptions|array<empty, empty> $options
      *
      * @throws JsonException
      *

--- a/src/Html.php
+++ b/src/Html.php
@@ -31,17 +31,25 @@ use Yiisoft\Json\Json;
  * @psalm-type ListHtmlOptions = HtmlOptions&array{
  *   tag?: string,
  *   encode?: bool,
- *   item?: Closure|null,
+ *   item?: Closure(string, array-key):string|null,
  *   separator?: string,
  *   itemOptions: HtmlOptions,
  * }
  * @psalm-type InputHtmlOptions = HtmlOptions&array {
- *   value?: string|null,
+ *   value?: string|int|float|\Stringable|bool|null,
+ *   disabled?: bool,
+ * }
+ * @psalm-type BooleanInputHtmlOptions = InputHtmlOptions&array{
+ *   label?: string|null,
+ *   labelOptions?: HtmlOptions|null,
+ *   wrapInput?: bool,
+ *   uncheck?: string|int|float|\Stringable|bool|null,
+ *   form?: string|null,
  * }
  * @psalm-type ListBoxHtmlOptions = HtmlOptions&array{
  *   size?: int,
  *   multiple?: bool,
- *   unselect?: bool,
+ *   unselect?: string|int|float|\Stringable|bool|null,
  *   disabled?: bool,
  * }
  */
@@ -426,6 +434,10 @@ final class Html
      * HTML-encoded using {@see encodeAttribute()}. If a value is null, the corresponding attribute will
      * not be rendered. See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
+     * @psalm-param HtmlOptions&array{
+     *   condition?: string|null,
+     * } $options
+     *
      * @throws JsonException
      *
      * @return string the generated script tag.
@@ -651,12 +663,15 @@ final class Html
      *
      * @param string $type the type attribute.
      * @param string|null $name the name attribute. If it is null, the name attribute will not be generated.
-     * @param bool|callable|float|int|string|null $value the value attribute. If it is null, the value attribute will
+     * @param bool|float|int|string|null $value the value attribute. If it is null, the value attribute will
      * not be generated.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
      * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}.
      * If a value is null, the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
+     *
+     * @psalm-param string|int|float|\Stringable|bool|null $value
+     * @psalm-param InputHtmlOptions $options
      *
      * @throws JsonException
      *
@@ -750,6 +765,8 @@ final class Html
      * If a value is null, the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
+     * @psalm-param InputHtmlOptions $options
+     *
      * @throws JsonException
      *
      * @return string the generated text input tag
@@ -763,12 +780,15 @@ final class Html
      * Generates a hidden input field.
      *
      * @param string $name the name attribute.
-     * @param bool|callable|float|int|string|null $value the value attribute.
+     * @param bool|float|int|string|null $value the value attribute.
      * If it is null, the value attribute will not be generated.
      * @param array $options the tag options in terms of name-value pairs. These will be rendered as the attributes of
      * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null,
      * the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
+     *
+     * @psalm-param string|int|float|\Stringable|bool|null $value
+     * @psalm-param InputHtmlOptions $options
      *
      * @throws JsonException
      *
@@ -788,6 +808,8 @@ final class Html
      * the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}. If a value is null,
      * the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
+     *
+     * @psalm-param InputHtmlOptions $options
      *
      * @throws JsonException
      *
@@ -811,6 +833,8 @@ final class Html
      * the attributes of the resulting tag. The values will be HTML-encoded using {@see encodeAttribute()}.
      * If a value is null, the corresponding attribute will not be rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
+     *
+     * @psalm-param InputHtmlOptions $options
      *
      * @throws JsonException
      *
@@ -861,6 +885,8 @@ final class Html
      * @param array $options the tag options in terms of name-value pairs.
      * See {@see booleanInput()} for details about accepted attributes.
      *
+     * @psalm-param BooleanInputHtmlOptions $options
+     *
      * @throws JsonException
      *
      * @return string the generated radio button tag
@@ -877,6 +903,8 @@ final class Html
      * @param bool $checked whether the checkbox should be checked.
      * @param array $options the tag options in terms of name-value pairs.
      * See {@see booleanInput()} for details about accepted attributes.
+     *
+     * @psalm-param BooleanInputHtmlOptions $options
      *
      * @throws JsonException
      *
@@ -913,14 +941,7 @@ final class Html
      * rendered.
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
-     * @psalm-param InputHtmlOptions&array{
-     *   label?: string|null,
-     *   labelOptions?: HtmlOptions|null,
-     *   wrapInput?: bool,
-     *   uncheck?: bool|callable|float|int|string|null,
-     *   form?: string|null,
-     *   disabled?: bool,
-     * } $options
+     * @psalm-param BooleanInputHtmlOptions $options
      *
      * @throws JsonException
      *
@@ -1014,6 +1035,7 @@ final class Html
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
      * @psalm-param iterable<array-key, string>|string|null $selection
+     * @psalm-param array<array-key, array|string> $items
      * @psalm-param ListBoxHtmlOptions|array<empty, empty> $options
      *
      * @throws JsonException
@@ -1082,6 +1104,7 @@ final class Html
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
      * @psalm-param iterable<array-key, string>|string|null $selection
+     * @psalm-param array<array-key, array|string> $items
      * @psalm-param ListBoxHtmlOptions|array<empty, empty> $options
      *
      * @throws JsonException
@@ -1153,12 +1176,15 @@ final class Html
      *
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
-     * @psalm-param HtmlOptions&array{
-     *   item?: Closure|null,
+     * @psalm-param iterable<array-key, string>|string|int|float|\Stringable|bool|null $selection
+     * @psalm-param array<array-key, string> $items
+     * @psalm-param InputHtmlOptions&array{
+     *   item?: Closure(int, string, string, bool, mixed):string|null,
      *   itemOptions?: HtmlOptions|null,
      *   encode?: bool,
      *   separator?: string|null,
      *   tag?: string|null,
+     *   unselect?: string|int|float|\Stringable|bool|null,
      * }|array<empty, empty> $options
      *
      * @throws JsonException
@@ -1175,7 +1201,7 @@ final class Html
             $selection = (string)$selection;
         }
 
-        /** @var Closure|null $formatter */
+        /** @var Closure(int, string, string, bool, mixed):string|null $formatter */
         $formatter = ArrayHelper::remove($options, 'item');
 
         /** @psalm-var HtmlOptions $itemOptions */
@@ -1189,6 +1215,8 @@ final class Html
 
         /** @var string $tag */
         $tag = ArrayHelper::remove($options, 'tag', 'div');
+
+        /** @psalm-var InputHtmlOptions&array{unselect?: string|int|float|\Stringable|bool|null} $options */
 
         $lines = [];
         $index = 0;
@@ -1257,6 +1285,17 @@ final class Html
      *
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
+     * @psalm-param iterable<array-key, string>|string|int|float|\Stringable|bool|null $selection
+     * @psalm-param array<array-key, string> $items
+     * @psalm-param InputHtmlOptions&array{
+     *   item?: Closure(int, string, string, bool, mixed):string|null,
+     *   itemOptions?: HtmlOptions|null,
+     *   encode?: bool,
+     *   separator?: string|null,
+     *   tag?: string|null,
+     *   unselect?: string|int|float|\Stringable|bool|null,
+     * }|array<empty, empty> $options
+     *
      * @throws JsonException
      *
      * @return string the generated radio button list
@@ -1269,11 +1308,22 @@ final class Html
             $selection = (string)$selection;
         }
 
+        /** @var Closure(int, string, string, bool, mixed):string|null $formatter */
         $formatter = ArrayHelper::remove($options, 'item');
+
+        /** @psalm-var HtmlOptions $itemOptions */
         $itemOptions = ArrayHelper::remove($options, 'itemOptions', []);
+
+        /** @var bool $encode */
         $encode = ArrayHelper::remove($options, 'encode', true);
+
+        /** @var string $separator */
         $separator = ArrayHelper::remove($options, 'separator', "\n");
+
+        /** @var string $tag */
         $tag = ArrayHelper::remove($options, 'tag', 'div');
+
+        /** @psalm-var InputHtmlOptions&array{unselect?: string|int|float|\Stringable|bool|null} $options */
 
         $hidden = '';
         if (isset($options['unselect'])) {
@@ -1378,6 +1428,7 @@ final class Html
      *
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
+     * @psalm-param array<array-key, string> $items
      * @psalm-param ListHtmlOptions $options
      *
      * @throws JsonException
@@ -1392,7 +1443,7 @@ final class Html
         /** @var bool $encode */
         $encode = ArrayHelper::remove($options, 'encode', true);
 
-        /** @var Closure|null $formatter */
+        /** @var Closure(string, array-key):string|null $formatter */
         $formatter = ArrayHelper::remove($options, 'item');
 
         /** @var string $separator */
@@ -1445,6 +1496,7 @@ final class Html
      *
      * See {@see renderTagAttributes()} for details on how attributes are being rendered.
      *
+     * @psalm-param array<array-key, string> $items
      * @psalm-param ListHtmlOptions $options
      *
      * @throws JsonException
@@ -1475,8 +1527,8 @@ final class Html
      * call. This method will take out these elements, if any: "prompt", "options" and "groups". See more details in
      * {@see dropDownList()} for the explanation of these elements.
      *
-     * @psalm-param array<array-key, array|string> $items
      * @psalm-param iterable<array-key, string>|string|null $selection
+     * @psalm-param array<array-key, array|string> $items
      *
      * @throws JsonException
      *
@@ -1487,6 +1539,18 @@ final class Html
         return static::renderSelectOptionTags($selection, $items, $tagOptions);
     }
 
+    /**
+     * @param $selection
+     * @param array $items
+     * @param array $tagOptions
+     *
+     * @psalm-param iterable<array-key, string>|string|int|float|\Stringable|bool|null $selection
+     * @psalm-param array<array-key, array|string> $items
+     *
+     * @return string
+     *
+     * @throws JsonException
+     */
     private static function renderSelectOptionTags($selection, array $items, array &$tagOptions): string
     {
         if (is_iterable($selection)) {
@@ -1495,9 +1559,13 @@ final class Html
             $selection = (string)$selection;
         }
 
-        $lines = [];
+        /** @var bool $encodeSpaces */
         $encodeSpaces = ArrayHelper::remove($tagOptions, 'encodeSpaces', false);
+
+        /** @var bool $encode */
         $encode = ArrayHelper::remove($tagOptions, 'encode', true);
+
+        $lines = [];
         if (isset($tagOptions['prompt'])) {
             $promptOptions = ['value' => ''];
             if (is_string($tagOptions['prompt'])) {
@@ -1571,7 +1639,7 @@ final class Html
      * @param array $attributes attributes to be rendered. The attribute values will be HTML-encoded using
      * {@see encodeAttribute()}.
      *
-     * @psalm-param HtmlOptions $attributes
+     * @psalm-param HtmlOptions|array<empty, empty> $attributes
      *
      * @throws JsonException
      *
@@ -1601,6 +1669,7 @@ final class Html
                 }
             } elseif (is_array($value)) {
                 if (in_array($name, self::DATA_ATTRIBUTES, true)) {
+                    /** @psalm-var array<array-key, array|string|\Stringable|null> $value */
                     foreach ($value as $n => $v) {
                         if (is_array($v)) {
                             $html .= " $name-$n='" . Json::htmlEncode($v) . "'";
@@ -1617,6 +1686,7 @@ final class Html
                     if (empty($value)) {
                         continue;
                     }
+                    /** @psalm-var array<string, string> $value */
                     $html .= " $name=\"" . self::encodeAttribute(self::cssStyleFromArray($value)) . '"';
                 } else {
                     $html .= " $name='" . Json::htmlEncode($value) . "'";

--- a/src/Html.php
+++ b/src/Html.php
@@ -1030,7 +1030,7 @@ final class Html
 
         unset($options['unselect']);
 
-        $selectOptions = self::renderSelectOptions($selection, $items, $options);
+        $selectOptions = self::renderSelectOptionTags($selection, $items, $options);
 
         return self::tag('select', "\n" . $selectOptions . "\n", $options);
     }
@@ -1114,7 +1114,7 @@ final class Html
             $hidden = '';
         }
 
-        $selectOptions = self::renderSelectOptions($selection, $items, $options);
+        $selectOptions = self::renderSelectOptionTags($selection, $items, $options);
 
         return $hidden . self::tag('select', "\n" . $selectOptions . "\n", $options);
     }
@@ -1482,7 +1482,12 @@ final class Html
      *
      * @return string the generated list options
      */
-    public static function renderSelectOptions($selection, array $items, array &$tagOptions = []): string
+    public static function renderSelectOptions($selection, array $items, array $tagOptions = []): string
+    {
+        return static::renderSelectOptionTags($selection, $items, $tagOptions);
+    }
+
+    private static function renderSelectOptionTags($selection, array $items, array &$tagOptions): string
     {
         if (is_iterable($selection)) {
             $selection = array_map('strval', (array)$selection);
@@ -1524,7 +1529,7 @@ final class Html
                     'encodeSpaces' => $encodeSpaces,
                     'encode' => $encode,
                 ];
-                $content = self::renderSelectOptions($selection, $value, $attrs);
+                $content = self::renderSelectOptionTags($selection, $value, $attrs);
                 $lines[] = self::tag('optgroup', "\n" . $content . "\n", $groupAttrs);
             } else {
                 $attrs = $options[$key] ?? [];

--- a/src/Html.php
+++ b/src/Html.php
@@ -1713,7 +1713,7 @@ final class Html
      * ```
      *
      * @param array $options the options to be modified.
-     * @param string[]|string $class the CSS class(es) to be added
+     * @param string|string[] $class the CSS class(es) to be added
      *
      * @psalm-param HtmlOptions $options
      *

--- a/src/Html.php
+++ b/src/Html.php
@@ -1865,8 +1865,8 @@ final class Html
      * For example,
      *
      * ```php
-     * print_r(Html::cssStyleFromArray(['width' => '100px', 'height' => '200px']));
-     * // will display: 'width: 100px; height: 200px;'
+     * // width: 100px; height: 200px;
+     * Html::cssStyleFromArray(['width' => '100px', 'height' => '200px']);
      * ```
      *
      * @param array<string, string> $style the CSS style array. The array keys are the CSS property names,
@@ -1893,8 +1893,8 @@ final class Html
      * For example,
      *
      * ```php
-     * print_r(Html::cssStyleToArray('width: 100px; height: 200px;'));
-     * // will display: ['width' => '100px', 'height' => '200px']
+     * // ['width' => '100px', 'height' => '200px']
+     * Html::cssStyleToArray('width: 100px; height: 200px;');
      * ```
      *
      * @param string $style the CSS style string

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Yiisoft\Html\Tests;
 
+use ArrayObject;
 use InvalidArgumentException;
 use Yiisoft\Html\Html;
+use Yiisoft\Html\Tests\Objects\ArrayAccessObject;
+use Yiisoft\Html\Tests\Objects\IterableObject;
 
 final class HtmlTest extends TestCase
 {
@@ -509,7 +512,7 @@ EOD;
 </select>
 EOD;
         $this->assertSameWithoutLE($expected, Html::dropDownList('test', [0], $this->getDataItems3(), ['multiple' => 'true']));
-        $this->assertSameWithoutLE($expected, Html::dropDownList('test', new \ArrayObject([0]), $this->getDataItems3(), ['multiple' => 'true']));
+        $this->assertSameWithoutLE($expected, Html::dropDownList('test', new ArrayObject([0]), $this->getDataItems3(), ['multiple' => 'true']));
 
         $expected = <<<'EOD'
 <select name="test[]" multiple="true" size="4">
@@ -519,7 +522,7 @@ EOD;
 </select>
 EOD;
         $this->assertSameWithoutLE($expected, Html::dropDownList('test', ['1', 'value3'], $this->getDataItems3(), ['multiple' => 'true']));
-        $this->assertSameWithoutLE($expected, Html::dropDownList('test', new \ArrayObject(['1', 'value3']), $this->getDataItems3(), ['multiple' => 'true']));
+        $this->assertSameWithoutLE($expected, Html::dropDownList('test', new ArrayObject(['1', 'value3']), $this->getDataItems3(), ['multiple' => 'true']));
     }
 
     public function testListBox(): void
@@ -608,7 +611,7 @@ EOD;
 <option value="value2" selected>text2</option>
 </select>
 EOD;
-        $this->assertSameWithoutLE($expected, Html::listBox('test', new \ArrayObject(['value1', 'value2']), $this->getDataItems()));
+        $this->assertSameWithoutLE($expected, Html::listBox('test', new ArrayObject(['value1', 'value2']), $this->getDataItems()));
 
         $expected = <<<'EOD'
 <select name="test" size="4">
@@ -618,7 +621,7 @@ EOD;
 </select>
 EOD;
         $this->assertSameWithoutLE($expected, Html::listBox('test', [0], $this->getDataItems3()));
-        $this->assertSameWithoutLE($expected, Html::listBox('test', new \ArrayObject([0]), $this->getDataItems3()));
+        $this->assertSameWithoutLE($expected, Html::listBox('test', new ArrayObject([0]), $this->getDataItems3()));
 
         $expected = <<<'EOD'
 <select name="test" size="4">
@@ -628,7 +631,7 @@ EOD;
 </select>
 EOD;
         $this->assertSameWithoutLE($expected, Html::listBox('test', ['1', 'value3'], $this->getDataItems3()));
-        $this->assertSameWithoutLE($expected, Html::listBox('test', new \ArrayObject(['1', 'value3']), $this->getDataItems3()));
+        $this->assertSameWithoutLE($expected, Html::listBox('test', new ArrayObject(['1', 'value3']), $this->getDataItems3()));
 
         $expected = <<<'EOD'
 <input type="hidden" name="test" value="none"><select name="test[]" size="4">
@@ -702,14 +705,24 @@ EOD;
             },
             'tag' => false,
         ]));
-
-
-        $this->assertSameWithoutLE($expected, Html::checkboxList('test', new \ArrayObject(['value2']), $this->getDataItems(), [
-            'item' => static function ($index, $label, $name, $checked, $value) {
-                return $index . Html::label($label . ' ' . Html::checkbox($name, $checked, ['value' => $value]));
-            },
-            'tag' => false,
-        ]));
+        $this->assertSameWithoutLE(
+            $expected,
+            Html::checkboxList('test', new ArrayObject(['value2']), $this->getDataItems(), [
+                'item' => static function ($index, $label, $name, $checked, $value) {
+                    return $index . Html::label($label . ' ' . Html::checkbox($name, $checked, ['value' => $value]));
+                },
+                'tag' => false,
+            ])
+        );
+        $this->assertSameWithoutLE(
+            $expected,
+            Html::checkboxList('test', new IterableObject(['value2']), $this->getDataItems(), [
+                'item' => static function ($index, $label, $name, $checked, $value) {
+                    return $index . Html::label($label . ' ' . Html::checkbox($name, $checked, ['value' => $value]));
+                },
+                'tag' => false,
+            ])
+        );
 
         $expected = <<<'EOD'
 <div><label><input type="checkbox" name="test[]" value="0" checked> zero</label>
@@ -717,7 +730,7 @@ EOD;
 <label><input type="checkbox" name="test[]" value="value3"> text3</label></div>
 EOD;
         $this->assertSameWithoutLE($expected, Html::checkboxList('test', [0], $this->getDataItems3()));
-        $this->assertSameWithoutLE($expected, Html::checkboxList('test', new \ArrayObject([0]), $this->getDataItems3()));
+        $this->assertSameWithoutLE($expected, Html::checkboxList('test', new ArrayObject([0]), $this->getDataItems3()));
 
         $expected = <<<'EOD'
 <div><label><input type="checkbox" name="test[]" value="0"> zero</label>
@@ -725,7 +738,7 @@ EOD;
 <label><input type="checkbox" name="test[]" value="value3" checked> text3</label></div>
 EOD;
         $this->assertSameWithoutLE($expected, Html::checkboxList('test', ['1', 'value3'], $this->getDataItems3()));
-        $this->assertSameWithoutLE($expected, Html::checkboxList('test', new \ArrayObject(['1', 'value3']), $this->getDataItems3()));
+        $this->assertSameWithoutLE($expected, Html::checkboxList('test', new ArrayObject(['1', 'value3']), $this->getDataItems3()));
 
         $expected = <<<'EOD'
 <div><label><input type="checkbox" name="test[]" value="0" any="42"> zero</label>
@@ -800,13 +813,24 @@ EOD;
             },
             'tag' => false,
         ]));
-
-        $this->assertSameWithoutLE($expected, Html::radioList('test', new \ArrayObject(['value2']), $this->getDataItems(), [
-            'item' => static function ($index, $label, $name, $checked, $value) {
-                return $index . Html::label($label . ' ' . Html::radio($name, $checked, ['value' => $value]));
-            },
-            'tag' => false,
-        ]));
+        $this->assertSameWithoutLE(
+            $expected,
+            Html::radioList('test', new ArrayObject(['value2']), $this->getDataItems(), [
+                'item' => static function ($index, $label, $name, $checked, $value) {
+                    return $index . Html::label($label . ' ' . Html::radio($name, $checked, ['value' => $value]));
+                },
+                'tag' => false,
+            ])
+        );
+        $this->assertSameWithoutLE(
+            $expected,
+            Html::radioList('test', new IterableObject(['value2']), $this->getDataItems(), [
+                'item' => static function ($index, $label, $name, $checked, $value) {
+                    return $index . Html::label($label . ' ' . Html::radio($name, $checked, ['value' => $value]));
+                },
+                'tag' => false,
+            ])
+        );
 
         $expected = <<<'EOD'
 <div><label><input type="radio" name="test" value="0" checked> zero</label>
@@ -814,7 +838,7 @@ EOD;
 <label><input type="radio" name="test" value="value3"> text3</label></div>
 EOD;
         $this->assertSameWithoutLE($expected, Html::radioList('test', [0], $this->getDataItems3()));
-        $this->assertSameWithoutLE($expected, Html::radioList('test', new \ArrayObject([0]), $this->getDataItems3()));
+        $this->assertSameWithoutLE($expected, Html::radioList('test', new ArrayObject([0]), $this->getDataItems3()));
 
         $expected = <<<'EOD'
 <div><label><input type="radio" name="test" value="0"> zero</label>
@@ -822,7 +846,7 @@ EOD;
 <label><input type="radio" name="test" value="value3" checked> text3</label></div>
 EOD;
         $this->assertSameWithoutLE($expected, Html::radioList('test', ['value3'], $this->getDataItems3()));
-        $this->assertSameWithoutLE($expected, Html::radioList('test', new \ArrayObject(['value3']), $this->getDataItems3()));
+        $this->assertSameWithoutLE($expected, Html::radioList('test', new ArrayObject(['value3']), $this->getDataItems3()));
 
         $expected = <<<'EOD'
 <div><label><input type="radio" name="test" value="1" checked any="42"> One</label>
@@ -971,6 +995,8 @@ EOD;
             'encodeSpaces' => true,
         ];
         $this->assertSameWithoutLE($expected, Html::renderSelectOptions(['value111', 'value1'], $data, $attributes));
+        $this->assertSameWithoutLE($expected, Html::renderSelectOptions(new ArrayObject(['value111', 'value1']), $data, $attributes));
+        $this->assertSameWithoutLE($expected, Html::renderSelectOptions(new IterableObject(['value111', 'value1']), $data, $attributes));
 
         $attributes = [
             'prompt' => 'please select<>',

--- a/tests/Objects/ArrayAccessObject.php
+++ b/tests/Objects/ArrayAccessObject.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Html\Tests;
+namespace Yiisoft\Html\Tests\Objects;
 
 use ArrayAccess;
 use Countable;

--- a/tests/Objects/IterableObject.php
+++ b/tests/Objects/IterableObject.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Objects;
+
+use ArrayIterator;
+use IteratorAggregate;
+
+final class IterableObject implements IteratorAggregate
+{
+    private array $data;
+
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    public function getIterator()
+    {
+        return new ArrayIterator($this->data);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    |  ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | -

- In Html::renderSelectOptions() pass 3 argument not by reference
- Fix: incorrect work with iterable $selection in methods checkboxList, radioList and renderSelectOptions
- Update dev dependencies
- Adopt Psalm (error level 1)
- Clean up