### PR TITLE
Add parameter $attributes to ListTag::strings()

### DIFF
--- a/src/Tag/Base/ListTag.php
+++ b/src/Tag/Base/ListTag.php
@@ -27,15 +27,17 @@ abstract class ListTag extends ContainerTag
 
     /**
      * @param string[] $strings Array of list items as strings.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
      * @param bool $encode Whether to encode strings passed.
      *
      * @return static
      */
-    public function strings(array $strings, bool $encode = true): self
+    public function strings(array $strings, array $attributes = [], bool $encode = true): self
     {
-        $items = array_map(static function (string $string) use ($encode) {
+        $items = array_map(static function (string $string) use ($attributes, $encode) {
             return Li::tag()
                 ->content($string)
+                ->attributes($attributes)
                 ->encode($encode);
         }, $strings);
         return $this->items(...$items);

--- a/tests/Tag/Base/ListTagTest.php
+++ b/tests/Tag/Base/ListTagTest.php
@@ -27,6 +27,16 @@ final class ListTagTest extends TestCase
         $this->assertSame("<test>\n<li>A</li>\n<li>B</li>\n</test>", (string)$tag);
     }
 
+    public function testStringsAttributes(): void
+    {
+        $tag = TestListTag::tag()->strings(['A', 'B'], ['class' => 'red']);
+
+        self::assertSame(
+            "<test>\n<li class=\"red\">A</li>\n<li class=\"red\">B</li>\n</test>",
+            (string)$tag
+        );
+    }
+
     public function testStringsEncode(): void
     {
         $tag = TestListTag::tag()->strings(['<b>A</b>', '<b>B</b>']);
@@ -39,9 +49,9 @@ final class ListTagTest extends TestCase
 
     public function testStringsWithoutEncode(): void
     {
-        $tag = TestListTag::tag()->strings(['<b>A</b>', '<b>B</b>'], false);
+        $tag = TestListTag::tag()->strings(['<b>A</b>', '<b>B</b>'], [], false);
 
-        $this->assertSame("<test>\n<li><b>A</b></li>\n<li><b>B</b></li>\n</test>", (string)$tag);
+        self::assertSame("<test>\n<li><b>A</b></li>\n<li><b>B</b></li>\n</test>", (string)$tag);
     }
 
     public function testImmutability(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | -

For example:

```php
echo Html::ul()->strings(['A', 'B'], ['class' => 'red']);
```

Result will be:

```html
<ul>
<li class="red">A</li>
<li class="red">B</li>
</li>
```