### PR TITLE
Add NotEncodeStringableInterface and allow accept array in ContentTag::content()

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ use Yiisoft\Html\Tag\Meta;
         'crossorigin' => 'anonymous'
     ]
 ) ?>
-<?= Html::cssFile('/css/site.css', ['rel' => 'stylesheet']); ?>
+<?= Html::cssFile('/css/site.css', ['rel' => 'stylesheet']) ?>
 
 <?= Html::openTag('footer', ['class' => 'footer']) ?>
     <?= Html::openTag('div', ['class' => 'container flex-fill']) ?>
@@ -71,7 +71,7 @@ use Yiisoft\Html\Tag\Meta;
 
 ## Tag objects usage
 
-Tag classes allow working with tag as is object and then get a HTML code by method `render()` or type casting to string. For example, code:
+Tag classes allow working with tag as is object and then get an HTML code by method `render()` or type casting to string. For example, code:
 
 ```php
 echo \Yiisoft\Html\Tag\Div::tag()

--- a/src/Html.php
+++ b/src/Html.php
@@ -48,13 +48,13 @@ use function strlen;
  * documentation of the {@see tag()} method for more details.
  *
  * @psalm-type HtmlAttributes = array<string, mixed>&array{
- *   id?: string|\Stringable|null,
- *   class?: string[]|string|\Stringable[]|\Stringable|null,
- *   style?: array<string, string>|\Stringable|string|null,
- *   data?: array<array-key, array|string|\Stringable|null>|string|\Stringable|null,
- *   data-ng?: array<array-key, array|string|\Stringable|null>|string|\Stringable|null,
- *   ng?: array<array-key, array|string|\Stringable|null>|string|\Stringable|null,
- *   aria?: array<array-key, array|string|\Stringable|null>|string|\Stringable|null,
+ *   id?: string|null,
+ *   class?: string[]|string|null,
+ *   style?: array<string, string>|string|null,
+ *   data?: array<array-key, array|string|null>|string|null,
+ *   data-ng?: array<array-key, array|string|null>|string|null,
+ *   ng?: array<array-key, array|string|null>|string|null,
+ *   aria?: array<array-key, array|string|null>|string|null,
  * }
  */
 final class Html
@@ -973,7 +973,7 @@ final class Html
             if (is_array($options['class'])) {
                 $options['class'] = self::mergeCssClasses($options['class'], (array)$class);
             } else {
-                $classes = preg_split('/\s+/', (string)$options['class'], -1, PREG_SPLIT_NO_EMPTY);
+                $classes = preg_split('/\s+/', $options['class'], -1, PREG_SPLIT_NO_EMPTY);
                 $options['class'] = implode(' ', self::mergeCssClasses($classes, (array)$class));
             }
         } else {

--- a/src/NoEncodeStringableInterface.php
+++ b/src/NoEncodeStringableInterface.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Html\Tag\Base;
+namespace Yiisoft\Html;
 
-interface NotEncodeStringableInterface
+interface NoEncodeStringableInterface
 {
     public function __toString(): string;
 }

--- a/src/NoEncodeStringableInterface.php
+++ b/src/NoEncodeStringableInterface.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Yiisoft\Html;
 
+/**
+ * An object that could be cast to string that should not be HTML-encoded when used.
+ */
 interface NoEncodeStringableInterface
 {
     public function __toString(): string;

--- a/src/Tag/Base/BooleanInputTag.php
+++ b/src/Tag/Base/BooleanInputTag.php
@@ -66,7 +66,7 @@ abstract class BooleanInputTag extends InputTag
     }
 
     /**
-     * @patam bool $encode Whether to encode label content. Defaults to `true`.
+     * @param bool $encode Whether to encode label content. Defaults to `true`.
      *
      * @return static
      */

--- a/src/Tag/Base/ContentTag.php
+++ b/src/Tag/Base/ContentTag.php
@@ -6,6 +6,7 @@ namespace Yiisoft\Html\Tag\Base;
 
 use Stringable;
 use Yiisoft\Html\Html;
+use Yiisoft\Html\NoEncodeStringableInterface;
 
 abstract class ContentTag extends NormalTag
 {
@@ -73,7 +74,7 @@ abstract class ContentTag extends NormalTag
     {
         $content = array_map(function ($item) {
             if ($this->encode ||
-                ($this->encode === null && !($item instanceof NotEncodeStringableInterface))
+                ($this->encode === null && !($item instanceof NoEncodeStringableInterface))
             ) {
                 $item = Html::encode($item, $this->doubleEncode);
             }

--- a/src/Tag/Base/ContentTag.php
+++ b/src/Tag/Base/ContentTag.php
@@ -68,7 +68,7 @@ abstract class ContentTag extends NormalTag
     public function addContent(...$content): self
     {
         $new = clone $this;
-        $new->content = array_merge($new->content, $content);
+        $new->content = [...$new->content, ...$content];
         return $new;
     }
 

--- a/src/Tag/Base/ContentTag.php
+++ b/src/Tag/Base/ContentTag.php
@@ -72,16 +72,18 @@ abstract class ContentTag extends NormalTag
      */
     final protected function generateContent(): string
     {
-        $content = array_map(function ($item) {
-            if ($this->encode ||
+        $content = '';
+        foreach ($this->content as $item) {
+            if (
+                $this->encode ||
                 ($this->encode === null && !($item instanceof NoEncodeStringableInterface))
             ) {
                 $item = Html::encode($item, $this->doubleEncode);
             }
 
-            return $item;
-        }, $this->content);
+            $content .= $item;
+        }
 
-        return implode('', $content);
+        return $content;
     }
 }

--- a/src/Tag/Base/ContentTag.php
+++ b/src/Tag/Base/ContentTag.php
@@ -55,14 +55,14 @@ abstract class ContentTag extends NormalTag
     }
 
     /**
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable ...$content Tag content.
      *
      * @return static
      */
-    final public function addContent($content): self
+    public function addContent(...$content): self
     {
         $new = clone $this;
-        $new->content[] = $content;
+        $new->content = array_merge($new->content, $content);
         return $new;
     }
 

--- a/src/Tag/Base/ContentTag.php
+++ b/src/Tag/Base/ContentTag.php
@@ -7,8 +7,6 @@ namespace Yiisoft\Html\Tag\Base;
 use Stringable;
 use Yiisoft\Html\Html;
 
-use function is_array;
-
 abstract class ContentTag extends NormalTag
 {
     private ?bool $encode = null;
@@ -45,14 +43,26 @@ abstract class ContentTag extends NormalTag
     }
 
     /**
-     * @param string|Stringable|string[]|Stringable[] $content Tag content.
+     * @param string|Stringable ...$content Tag content.
      *
      * @return static
      */
-    final public function content($content): self
+    final public function content(...$content): self
     {
         $new = clone $this;
-        $new->content = is_array($content) ? $content : [$content];
+        $new->content = $content;
+        return $new;
+    }
+
+    /**
+     * @param string|Stringable $content Tag content.
+     *
+     * @return static
+     */
+    final public function addContent($content): self
+    {
+        $new = clone $this;
+        $new->content[] = $content;
         return $new;
     }
 

--- a/src/Tag/Base/ContentTag.php
+++ b/src/Tag/Base/ContentTag.php
@@ -19,7 +19,12 @@ abstract class ContentTag extends NormalTag
     private array $content = [];
 
     /**
-     * @param bool|null $encode Whether to encode tag content. Defaults to `null`.
+     * @param bool|null $encode Whether to encode tag content. Supported values:
+     *  - `null`: stringable objects that implement interface {@see NoEncodeStringableInterface} not encoded,
+     *    everything else is encoded;
+     *  - `true`: any content is encoded;
+     *  - `false`: nothing is encoded.
+     * Defaults to `null`.
      *
      * @return static
      */

--- a/src/Tag/Base/ContentTag.php
+++ b/src/Tag/Base/ContentTag.php
@@ -12,7 +12,6 @@ use function is_array;
 abstract class ContentTag extends NormalTag
 {
     private ?bool $encode = null;
-    private ?bool $encodeSpaces = null;
     private bool $doubleEncode = true;
 
     /**
@@ -29,18 +28,6 @@ abstract class ContentTag extends NormalTag
     {
         $new = clone $this;
         $new->encode = $encode;
-        return $new;
-    }
-
-    /**
-     * @param bool|null $encodeSpaces Whether to encode spaces in tag content with `&nbsp;` character. Defaults to `null`.
-     *
-     * @return static
-     */
-    final public function encodeSpaces(?bool $encodeSpaces): self
-    {
-        $new = clone $this;
-        $new->encodeSpaces = $encodeSpaces;
         return $new;
     }
 
@@ -79,10 +66,6 @@ abstract class ContentTag extends NormalTag
                 ($this->encode === null && !($item instanceof NotEncodeStringableInterface))
             ) {
                 $item = Html::encode($item, $this->doubleEncode);
-            }
-
-            if ($this->encodeSpaces) {
-                $item = str_replace(' ', '&nbsp;', (string)$item);
             }
 
             return $item;

--- a/src/Tag/Base/ContentTag.php
+++ b/src/Tag/Base/ContentTag.php
@@ -20,7 +20,7 @@ abstract class ContentTag extends NormalTag
 
     /**
      * @param bool|null $encode Whether to encode tag content. Supported values:
-     *  - `null`: stringable objects that implement interface {@see NoEncodeStringableInterface} not encoded,
+     *  - `null`: stringable objects that implement interface {@see NoEncodeStringableInterface} are not encoded,
      *    everything else is encoded;
      *  - `true`: any content is encoded;
      *  - `false`: nothing is encoded.

--- a/src/Tag/Base/ContentTag.php
+++ b/src/Tag/Base/ContentTag.php
@@ -79,10 +79,7 @@ abstract class ContentTag extends NormalTag
     {
         $content = '';
         foreach ($this->content as $item) {
-            if (
-                $this->encode ||
-                ($this->encode === null && !($item instanceof NoEncodeStringableInterface))
-            ) {
+            if ($this->encode || ($this->encode === null && !($item instanceof NoEncodeStringableInterface))) {
                 $item = Html::encode($item, $this->doubleEncode);
             }
 

--- a/src/Tag/Base/NotEncodeStringableInterface.php
+++ b/src/Tag/Base/NotEncodeStringableInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag\Base;
+
+interface NotEncodeStringableInterface
+{
+    public function __toString(): string;
+}

--- a/src/Tag/Base/Tag.php
+++ b/src/Tag/Base/Tag.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace Yiisoft\Html\Tag\Base;
 
 use Yiisoft\Html\Html;
+use Yiisoft\Html\NoEncodeStringableInterface;
 
 /**
  * HTML tag. Base class for all tags.
  */
-abstract class Tag implements NotEncodeStringableInterface
+abstract class Tag implements NoEncodeStringableInterface
 {
     protected array $attributes = [];
 

--- a/src/Tag/Base/Tag.php
+++ b/src/Tag/Base/Tag.php
@@ -9,7 +9,7 @@ use Yiisoft\Html\Html;
 /**
  * HTML tag. Base class for all tags.
  */
-abstract class Tag
+abstract class Tag implements NotEncodeStringableInterface
 {
     protected array $attributes = [];
 

--- a/src/Tag/CustomTag.php
+++ b/src/Tag/CustomTag.php
@@ -187,10 +187,7 @@ final class CustomTag extends Tag
     {
         $content = '';
         foreach ($this->content as $item) {
-            if (
-                $this->encode ||
-                ($this->encode === null && !($item instanceof NoEncodeStringableInterface))
-            ) {
+            if ($this->encode || ($this->encode === null && !($item instanceof NoEncodeStringableInterface))) {
                 $item = Html::encode($item, $this->doubleEncode);
             }
 

--- a/src/Tag/CustomTag.php
+++ b/src/Tag/CustomTag.php
@@ -44,7 +44,6 @@ final class CustomTag extends Tag
 
     private string $name;
     private bool $encode = true;
-    private bool $encodeSpaces = false;
     private bool $doubleEncode = true;
     private string $content = '';
 
@@ -102,18 +101,6 @@ final class CustomTag extends Tag
     {
         $new = clone $this;
         $new->encode = $encode;
-        return $new;
-    }
-
-    /**
-     * @param bool $encodeSpaces Whether to encode spaces in tag content with `&nbsp;` character. Defaults to `false`.
-     *
-     * @return static
-     */
-    public function encodeSpaces(bool $encodeSpaces): self
-    {
-        $new = clone $this;
-        $new->encodeSpaces = $encodeSpaces;
         return $new;
     }
 
@@ -178,9 +165,6 @@ final class CustomTag extends Tag
         $content = $this->content;
         if ($this->encode) {
             $content = Html::encode($this->content, $this->doubleEncode);
-        }
-        if ($this->encodeSpaces) {
-            $content = str_replace(' ', '&nbsp;', $content);
         }
         return $content;
     }

--- a/src/Tag/CustomTag.php
+++ b/src/Tag/CustomTag.php
@@ -148,7 +148,7 @@ final class CustomTag extends Tag
     public function addContent(...$content): self
     {
         $new = clone $this;
-        $new->content = array_merge($new->content, $content);
+        $new->content = [...$new->content, ...$content];
         return $new;
     }
 

--- a/src/Tag/CustomTag.php
+++ b/src/Tag/CustomTag.php
@@ -100,7 +100,7 @@ final class CustomTag extends Tag
 
     /**
      * @param bool|null $encode Whether to encode tag content. Supported values:
-     *  - `null`: stringable objects that implement interface {@see NoEncodeStringableInterface} not encoded,
+     *  - `null`: stringable objects that implement interface {@see NoEncodeStringableInterface} are not encoded,
      *    everything else is encoded;
      *  - `true`: any content is encoded;
      *  - `false`: nothing is encoded.

--- a/src/Tag/CustomTag.php
+++ b/src/Tag/CustomTag.php
@@ -6,7 +6,7 @@ namespace Yiisoft\Html\Tag;
 
 use Stringable;
 use Yiisoft\Html\Html;
-use Yiisoft\Html\Tag\Base\NotEncodeStringableInterface;
+use Yiisoft\Html\NoEncodeStringableInterface;
 use Yiisoft\Html\Tag\Base\Tag;
 
 /**
@@ -182,7 +182,7 @@ final class CustomTag extends Tag
     {
         $content = array_map(function ($item) {
             if ($this->encode ||
-                ($this->encode === null && !($item instanceof NotEncodeStringableInterface))
+                ($this->encode === null && !($item instanceof NoEncodeStringableInterface))
             ) {
                 $item = Html::encode($item, $this->doubleEncode);
             }

--- a/src/Tag/CustomTag.php
+++ b/src/Tag/CustomTag.php
@@ -180,16 +180,18 @@ final class CustomTag extends Tag
      */
     private function generateContent(): string
     {
-        $content = array_map(function ($item) {
-            if ($this->encode ||
+        $content = '';
+        foreach ($this->content as $item) {
+            if (
+                $this->encode ||
                 ($this->encode === null && !($item instanceof NoEncodeStringableInterface))
             ) {
                 $item = Html::encode($item, $this->doubleEncode);
             }
 
-            return $item;
-        }, $this->content);
+            $content .= $item;
+        }
 
-        return implode('', $content);
+        return $content;
     }
 }

--- a/src/Tag/CustomTag.php
+++ b/src/Tag/CustomTag.php
@@ -136,14 +136,14 @@ final class CustomTag extends Tag
     }
 
     /**
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable ...$content Tag content.
      *
      * @return static
      */
-    public function addContent($content): self
+    public function addContent(...$content): self
     {
         $new = clone $this;
-        $new->content[] = $content;
+        $new->content = array_merge($new->content, $content);
         return $new;
     }
 

--- a/src/Tag/CustomTag.php
+++ b/src/Tag/CustomTag.php
@@ -99,7 +99,12 @@ final class CustomTag extends Tag
     }
 
     /**
-     * @param bool|null $encode Whether to encode tag content. Defaults to `null`.
+     * @param bool|null $encode Whether to encode tag content. Supported values:
+     *  - `null`: stringable objects that implement interface {@see NoEncodeStringableInterface} not encoded,
+     *    everything else is encoded;
+     *  - `true`: any content is encoded;
+     *  - `false`: nothing is encoded.
+     * Defaults to `null`.
      *
      * @return static
      */

--- a/src/Widget/CheckboxList/CheckboxList.php
+++ b/src/Widget/CheckboxList/CheckboxList.php
@@ -8,6 +8,7 @@ use Closure;
 use InvalidArgumentException;
 use Yiisoft\Arrays\ArrayHelper;
 use Yiisoft\Html\Html;
+use Yiisoft\Html\Tag\Base\NotEncodeStringableInterface;
 use Yiisoft\Html\Tag\Input;
 
 use function is_array;
@@ -15,7 +16,7 @@ use function is_array;
 /**
  * CheckboxList represents a list of checkboxes and their corresponding labels.
  */
-final class CheckboxList
+final class CheckboxList implements NotEncodeStringableInterface
 {
     private ?string $containerTag = 'div';
     private array $containerAttributes = [];
@@ -258,5 +259,10 @@ final class CheckboxList
             ->labelEncode($item->encodeLabel);
 
         return $checkbox->render();
+    }
+
+    public function __toString(): string
+    {
+        return $this->render();
     }
 }

--- a/src/Widget/CheckboxList/CheckboxList.php
+++ b/src/Widget/CheckboxList/CheckboxList.php
@@ -8,7 +8,7 @@ use Closure;
 use InvalidArgumentException;
 use Yiisoft\Arrays\ArrayHelper;
 use Yiisoft\Html\Html;
-use Yiisoft\Html\Tag\Base\NotEncodeStringableInterface;
+use Yiisoft\Html\NoEncodeStringableInterface;
 use Yiisoft\Html\Tag\Input;
 
 use function is_array;
@@ -16,7 +16,7 @@ use function is_array;
 /**
  * CheckboxList represents a list of checkboxes and their corresponding labels.
  */
-final class CheckboxList implements NotEncodeStringableInterface
+final class CheckboxList implements NoEncodeStringableInterface
 {
     private ?string $containerTag = 'div';
     private array $containerAttributes = [];

--- a/src/Widget/RadioList/RadioList.php
+++ b/src/Widget/RadioList/RadioList.php
@@ -6,13 +6,13 @@ namespace Yiisoft\Html\Widget\RadioList;
 
 use Closure;
 use Yiisoft\Html\Html;
-use Yiisoft\Html\Tag\Base\NotEncodeStringableInterface;
+use Yiisoft\Html\NoEncodeStringableInterface;
 use Yiisoft\Html\Tag\Input;
 
 /**
  * RadioList represents a list of radios and their corresponding labels.
  */
-final class RadioList implements NotEncodeStringableInterface
+final class RadioList implements NoEncodeStringableInterface
 {
     private ?string $containerTag = 'div';
     private array $containerAttributes = [];

--- a/src/Widget/RadioList/RadioList.php
+++ b/src/Widget/RadioList/RadioList.php
@@ -6,12 +6,13 @@ namespace Yiisoft\Html\Widget\RadioList;
 
 use Closure;
 use Yiisoft\Html\Html;
+use Yiisoft\Html\Tag\Base\NotEncodeStringableInterface;
 use Yiisoft\Html\Tag\Input;
 
 /**
  * RadioList represents a list of radios and their corresponding labels.
  */
-final class RadioList
+final class RadioList implements NotEncodeStringableInterface
 {
     private ?string $containerTag = 'div';
     private array $containerAttributes = [];
@@ -230,5 +231,10 @@ final class RadioList
             ->labelEncode($item->encodeLabel);
 
         return $radio->render();
+    }
+
+    public function __toString(): string
+    {
+        return $this->render();
     }
 }

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -681,31 +681,6 @@ final class HtmlTest extends TestCase
         $this->assertSame('width: 100px;', $options['style']);
     }
 
-    private function getDataItems(): array
-    {
-        return [
-            'value1' => 'text1',
-            'value2' => 'text2',
-        ];
-    }
-
-    private function getDataItems2(): array
-    {
-        return [
-            'value1<>' => 'text1<>',
-            'value  2' => 'text  2',
-        ];
-    }
-
-    private function getDataItems3(): array
-    {
-        return [
-            'zero',
-            'one',
-            'value3' => 'text3',
-        ];
-    }
-
     public function dataNormalizeRegexpPattern(): array
     {
         return [

--- a/tests/Objects/StringableObject.php
+++ b/tests/Objects/StringableObject.php
@@ -6,8 +6,15 @@ namespace Yiisoft\Html\Tests\Objects;
 
 final class StringableObject
 {
+    private string $string;
+
+    public function __construct(string $string = 'string')
+    {
+        $this->string = $string;
+    }
+
     public function __toString(): string
     {
-        return 'string';
+        return $this->string;
     }
 }

--- a/tests/Tag/Base/ContentTagTest.php
+++ b/tests/Tag/Base/ContentTagTest.php
@@ -8,7 +8,9 @@ use PHPUnit\Framework\TestCase;
 use Stringable;
 use Yiisoft\Html\Tag\P;
 use Yiisoft\Html\Tag\Span;
+use Yiisoft\Html\Tests\Objects\StringableObject;
 use Yiisoft\Html\Tests\Objects\TestContentTag;
+use function is_array;
 
 final class ContentTagTest extends TestCase
 {
@@ -56,7 +58,10 @@ final class ContentTagTest extends TestCase
      */
     public function testContent(string $expected, $content): void
     {
-        self::assertSame($expected, TestContentTag::tag()->content($content)->render());
+        $tag = TestContentTag::tag();
+        $tag = is_array($content) ? $tag->content(...$content) : $tag->content($content);
+
+        self::assertSame($expected, $tag->render());
     }
 
     public function testEncodeContent(): void
@@ -70,11 +75,24 @@ final class ContentTagTest extends TestCase
         );
     }
 
+    public function testAddContent(): void
+    {
+        self::assertSame(
+            '<test>Hello World</test>',
+            TestContentTag::tag()
+                ->content('Hello')
+                ->addContent(' ')
+                ->addContent(new StringableObject('World'))
+                ->render()
+        );
+    }
+
     public function testImmutability(): void
     {
         $tag = TestContentTag::tag();
         self::assertNotSame($tag, $tag->encode(true));
         self::assertNotSame($tag, $tag->doubleEncode(true));
         self::assertNotSame($tag, $tag->content(''));
+        self::assertNotSame($tag, $tag->addContent(''));
     }
 }

--- a/tests/Tag/Base/ContentTagTest.php
+++ b/tests/Tag/Base/ContentTagTest.php
@@ -54,7 +54,7 @@ final class ContentTagTest extends TestCase
     /**
      * @dataProvider dataContent
      *
-     * @param string|Stringable|string[]|Stringable[] $content
+     * @param string|string[]|Stringable|Stringable[] $content
      */
     public function testContent(string $expected, $content): void
     {

--- a/tests/Tag/Base/ContentTagTest.php
+++ b/tests/Tag/Base/ContentTagTest.php
@@ -87,6 +87,17 @@ final class ContentTagTest extends TestCase
         );
     }
 
+    public function testAddContentVariadic(): void
+    {
+        self::assertSame(
+            '<test>123</test>',
+            TestContentTag::tag()
+                ->content('1')
+                ->addContent(...['2', '3'])
+                ->render()
+        );
+    }
+
     public function testImmutability(): void
     {
         $tag = TestContentTag::tag();

--- a/tests/Tag/Base/ContentTagTest.php
+++ b/tests/Tag/Base/ContentTagTest.php
@@ -28,14 +28,6 @@ final class ContentTagTest extends TestCase
         );
     }
 
-    public function testEncodeSpaces(): void
-    {
-        self::assertSame(
-            '<test>hello&nbsp;world</test>',
-            (string)TestContentTag::tag()->content('hello world')->encodeSpaces(true)
-        );
-    }
-
     public function testWithoutDoubleEncode(): void
     {
         self::assertSame(
@@ -51,8 +43,8 @@ final class ContentTagTest extends TestCase
             'string-tag' => ['<test>&lt;p&gt;Hi!&lt;/p&gt;</test>', '<p>Hi!</p>'],
             'object-tag' => ['<test><p>Hi!</p></test>', P::tag()->content('Hi!')],
             'array' => [
-                '<test>Hello, <span>World</span>!</test>',
-                ['Hello', ', ', Span::tag()->content('World'), '!'],
+                '<test>Hello &gt; <span>World</span>!</test>',
+                ['Hello', ' > ', Span::tag()->content('World'), '!'],
             ],
         ];
     }
@@ -67,11 +59,21 @@ final class ContentTagTest extends TestCase
         self::assertSame($expected, TestContentTag::tag()->content($content)->render());
     }
 
+    public function testEncodeContent(): void
+    {
+        self::assertSame(
+            '<test>&lt;p&gt;Hi!&lt;/p&gt;</test>',
+            TestContentTag::tag()
+                ->encode(true)
+                ->content(P::tag()->content('Hi!'))
+                ->render()
+        );
+    }
+
     public function testImmutability(): void
     {
         $tag = TestContentTag::tag();
         self::assertNotSame($tag, $tag->encode(true));
-        self::assertNotSame($tag, $tag->encodeSpaces(true));
         self::assertNotSame($tag, $tag->doubleEncode(true));
         self::assertNotSame($tag, $tag->content(''));
     }

--- a/tests/Tag/Base/ContentTagTest.php
+++ b/tests/Tag/Base/ContentTagTest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Yiisoft\Html\Tests\Tag\Base;
 
 use PHPUnit\Framework\TestCase;
+use Stringable;
+use Yiisoft\Html\Tag\P;
+use Yiisoft\Html\Tag\Span;
 use Yiisoft\Html\Tests\Objects\TestContentTag;
 
 final class ContentTagTest extends TestCase
@@ -41,12 +44,27 @@ final class ContentTagTest extends TestCase
         );
     }
 
-    public function testContent(): void
+    public function dataContent(): array
     {
-        self::assertSame(
-            '<test>hello</test>',
-            (string)TestContentTag::tag()->content('hello')
-        );
+        return [
+            'string' => ['<test>hello</test>', 'hello'],
+            'string-tag' => ['<test>&lt;p&gt;Hi!&lt;/p&gt;</test>', '<p>Hi!</p>'],
+            'object-tag' => ['<test><p>Hi!</p></test>', P::tag()->content('Hi!')],
+            'array' => [
+                '<test>Hello, <span>World</span>!</test>',
+                ['Hello', ', ', Span::tag()->content('World'), '!'],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataContent
+     *
+     * @param string|Stringable|string[]|Stringable[] $content
+     */
+    public function testContent(string $expected, $content): void
+    {
+        self::assertSame($expected, TestContentTag::tag()->content($content)->render());
     }
 
     public function testImmutability(): void

--- a/tests/Tag/CustomTagTest.php
+++ b/tests/Tag/CustomTagTest.php
@@ -84,14 +84,6 @@ final class CustomTagTest extends TestCase
         );
     }
 
-    public function testEncodeSpaces(): void
-    {
-        self::assertSame(
-            '<test>hello&nbsp;world</test>',
-            (string)CustomTag::name('test')->content('hello world')->encodeSpaces(true)
-        );
-    }
-
     public function testWithoutDoubleEncode(): void
     {
         self::assertSame(
@@ -130,7 +122,6 @@ final class CustomTagTest extends TestCase
         self::assertNotSame($tag, $tag->normal());
         self::assertNotSame($tag, $tag->void());
         self::assertNotSame($tag, $tag->encode(true));
-        self::assertNotSame($tag, $tag->encodeSpaces(true));
         self::assertNotSame($tag, $tag->doubleEncode(true));
         self::assertNotSame($tag, $tag->content(''));
     }

--- a/tests/Tag/CustomTagTest.php
+++ b/tests/Tag/CustomTagTest.php
@@ -114,11 +114,11 @@ final class CustomTagTest extends TestCase
     /**
      * @dataProvider dataContent
      *
-     * @param string|Stringable|string[]|Stringable[] $content
+     * @param string|string[]|Stringable|Stringable[] $content
      */
     public function testContent(string $expected, $content): void
     {
-        $tag =  CustomTag::name('test');
+        $tag = CustomTag::name('test');
         $tag = is_array($content) ? $tag->content(...$content) : $tag->content($content);
 
         self::assertSame($expected, $tag->render());

--- a/tests/Tag/CustomTagTest.php
+++ b/tests/Tag/CustomTagTest.php
@@ -5,7 +5,13 @@ declare(strict_types=1);
 namespace Yiisoft\Html\Tests\Tag;
 
 use PHPUnit\Framework\TestCase;
+use Stringable;
 use Yiisoft\Html\Tag\CustomTag;
+use Yiisoft\Html\Tag\P;
+use Yiisoft\Html\Tag\Span;
+use Yiisoft\Html\Tests\Objects\StringableObject;
+
+use function is_array;
 
 final class CustomTagTest extends TestCase
 {
@@ -92,11 +98,52 @@ final class CustomTagTest extends TestCase
         );
     }
 
-    public function testContent(): void
+    public function dataContent(): array
+    {
+        return [
+            'string' => ['<test>hello</test>', 'hello'],
+            'string-tag' => ['<test>&lt;p&gt;Hi!&lt;/p&gt;</test>', '<p>Hi!</p>'],
+            'object-tag' => ['<test><p>Hi!</p></test>', P::tag()->content('Hi!')],
+            'array' => [
+                '<test>Hello &gt; <span>World</span>!</test>',
+                ['Hello', ' > ', Span::tag()->content('World'), '!'],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataContent
+     *
+     * @param string|Stringable|string[]|Stringable[] $content
+     */
+    public function testContent(string $expected, $content): void
+    {
+        $tag =  CustomTag::name('test');
+        $tag = is_array($content) ? $tag->content(...$content) : $tag->content($content);
+
+        self::assertSame($expected, $tag->render());
+    }
+
+    public function testEncodeContent(): void
     {
         self::assertSame(
-            '<test>hello</test>',
-            (string)CustomTag::name('test')->content('hello')
+            '<test>&lt;p&gt;Hi!&lt;/p&gt;</test>',
+            CustomTag::name('test')
+                ->encode(true)
+                ->content(P::tag()->content('Hi!'))
+                ->render()
+        );
+    }
+
+    public function testAddContent(): void
+    {
+        self::assertSame(
+            '<test>Hello World</test>',
+            CustomTag::name('test')
+                ->content('Hello')
+                ->addContent(' ')
+                ->addContent(new StringableObject('World'))
+                ->render()
         );
     }
 
@@ -124,5 +171,6 @@ final class CustomTagTest extends TestCase
         self::assertNotSame($tag, $tag->encode(true));
         self::assertNotSame($tag, $tag->doubleEncode(true));
         self::assertNotSame($tag, $tag->content(''));
+        self::assertNotSame($tag, $tag->addContent(''));
     }
 }

--- a/tests/Tag/CustomTagTest.php
+++ b/tests/Tag/CustomTagTest.php
@@ -147,6 +147,17 @@ final class CustomTagTest extends TestCase
         );
     }
 
+    public function testAddContentVariadic(): void
+    {
+        self::assertSame(
+            '<test>123</test>',
+            CustomTag::name('test')
+                ->content('1')
+                ->addContent(...['2', '3'])
+                ->render()
+        );
+    }
+
     public function testOpen(): void
     {
         self::assertSame(

--- a/tests/Widget/CheckboxListTest.php
+++ b/tests/Widget/CheckboxListTest.php
@@ -479,6 +479,14 @@ final class CheckboxListTest extends TestCase
         );
     }
 
+    public function testStringable(): void
+    {
+        self::assertSame(
+            "<div>\n</div>",
+            (string)CheckboxList::create('test'),
+        );
+    }
+
     public function testImmutability(): void
     {
         $widget = CheckboxList::create('test');

--- a/tests/Widget/RadioListTest.php
+++ b/tests/Widget/RadioListTest.php
@@ -449,6 +449,14 @@ final class RadioListTest extends TestCase
         );
     }
 
+    public function testStringable(): void
+    {
+        self::assertSame(
+            "<div>\n</div>",
+            (string)RadioList::create('test'),
+        );
+    }
+
     public function testImmutability(): void
     {
         $widget = RadioList::create('test');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | -

Implementaion of ideas from https://github.com/yiisoft/html/issues/49#issuecomment-753452870

- Add `NotEncodeStringableInterface`. Objects implemnted this interface will not be encoded by default in tag contents.
- `ContentTag::content()` and `CustomTag::content()` use variadic `$content` argument.
- Add method `__toString()` to `CheckboxList` and `RadioList`.
- Remove `ContentTag::encodeSpaces()` and `CustomTag::encodeSpaces()`.
- `ContentTag` and `CustomTag` use default encode as `null`. In this mode encode all, exclude stringable object implemented `NotEncodeStringableInterface`.

Example:

```php
$items = [
    'Hello > ',
    Span::tag()->content('World')
];
echo P::tag()->content(...$items)->addContent('!');
```

Result will be:

```html
<p>Hello &gt; <span>World</span>!</p>
```

