### PR TITLE
Add tags `Em`, `Strong`, `B` and `I`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
 # Yii HTML Change Log
 
-
 ## 1.2.1 under development
 
-- no changes in this release.
-
+- Enh #74: Add classes for tags `Em`, `Strong`, `B` and `I` (vjik)
 
 ## 1.2.0 May 04, 2021
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@
 
 The package provides:
 
-- tag classes `A`, `Br`, `Button`, `Div`, `Img`, `Input` (and specialized `Checkbox`, `Radio`), `Label`, `Li`, `Link`,
-  `Meta`, `Ol`, `Optgroup`, `Option`, `P`, `Script`, `Select`, `Span`, `Style`, `Textarea`, `Ul`, `Table`,
+- tag classes `A`, `B`, `Br`, `Button`, `Div`, `Em`, `I`, `Img`, `Input` (and specialized `Checkbox`, `Radio`), `Label`, `Li`, `Link`,
+  `Meta`, `Ol`, `Optgroup`, `Option`, `P`, `Script`, `Select`, `Span`, `Strong`, `Style`, `Textarea`, `Ul`, `Table`,
   `Caption`, `Colgroup`, `Col`, `Thead`, `Tbody`, `Tfoot`, `Tr`, `Th`, `Td`;
 - `CustomTag` class that helps to generate custom tag with any attributes;
 - HTML widgets `CheckboxList` and `RadioList`;
@@ -183,13 +183,17 @@ Overall the helper has the following method groups.
 
 #### Base tags
 
+- b
 - div
+- em
+- i
 - img
 - meta
 - p
 - br
 - script
 - span
+- strong
 - style
 
 #### List tags

--- a/psalm.xml
+++ b/psalm.xml
@@ -7,8 +7,5 @@
 >
     <projectFiles>
         <directory name="src" />
-        <ignoreFiles>
-            <directory name="vendor" />
-        </ignoreFiles>
     </projectFiles>
 </psalm>

--- a/src/Html.php
+++ b/src/Html.php
@@ -9,6 +9,7 @@ use JsonException;
 use Stringable;
 use ValueError;
 use Yiisoft\Html\Tag\A;
+use Yiisoft\Html\Tag\B;
 use Yiisoft\Html\Tag\Br;
 use Yiisoft\Html\Tag\Button;
 use Yiisoft\Html\Tag\Caption;
@@ -16,6 +17,8 @@ use Yiisoft\Html\Tag\Col;
 use Yiisoft\Html\Tag\Colgroup;
 use Yiisoft\Html\Tag\CustomTag;
 use Yiisoft\Html\Tag\Div;
+use Yiisoft\Html\Tag\Em;
+use Yiisoft\Html\Tag\I;
 use Yiisoft\Html\Tag\Img;
 use Yiisoft\Html\Tag\Input;
 use Yiisoft\Html\Tag\Input\Checkbox;
@@ -31,6 +34,7 @@ use Yiisoft\Html\Tag\P;
 use Yiisoft\Html\Tag\Script;
 use Yiisoft\Html\Tag\Select;
 use Yiisoft\Html\Tag\Span;
+use Yiisoft\Html\Tag\Strong;
 use Yiisoft\Html\Tag\Style;
 use Yiisoft\Html\Tag\Table;
 use Yiisoft\Html\Tag\Tbody;
@@ -829,6 +833,74 @@ final class Html
     public static function span($content = '', array $attributes = []): Span
     {
         $tag = Span::tag();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Em} tag.
+     *
+     * @param string|Stringable $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     *
+     * @psalm-param HtmlAttributes|array<empty, empty> $attributes
+     */
+    public static function em($content = '', array $attributes = []): Em
+    {
+        $tag = Em::tag();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Strong} tag.
+     *
+     * @param string|Stringable $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     *
+     * @psalm-param HtmlAttributes|array<empty, empty> $attributes
+     */
+    public static function strong($content = '', array $attributes = []): Strong
+    {
+        $tag = Strong::tag();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see B} tag.
+     *
+     * @param string|Stringable $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     *
+     * @psalm-param HtmlAttributes|array<empty, empty> $attributes
+     */
+    public static function b($content = '', array $attributes = []): B
+    {
+        $tag = B::tag();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see I} tag.
+     *
+     * @param string|Stringable $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     *
+     * @psalm-param HtmlAttributes|array<empty, empty> $attributes
+     */
+    public static function i($content = '', array $attributes = []): I
+    {
+        $tag = I::tag();
         if (!empty($attributes)) {
             $tag = $tag->attributes($attributes);
         }

--- a/src/Tag/B.php
+++ b/src/Tag/B.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://www.w3.org/TR/html52/textlevel-semantics.html#the-b-element
+ */
+final class B extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'b';
+    }
+}

--- a/src/Tag/Em.php
+++ b/src/Tag/Em.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://www.w3.org/TR/html52/textlevel-semantics.html#the-em-element
+ */
+final class Em extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'em';
+    }
+}

--- a/src/Tag/I.php
+++ b/src/Tag/I.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://www.w3.org/TR/html52/textlevel-semantics.html#the-i-element
+ */
+final class I extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'i';
+    }
+}

--- a/src/Tag/Strong.php
+++ b/src/Tag/Strong.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://www.w3.org/TR/html52/textlevel-semantics.html#the-strong-element
+ */
+final class Strong extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'strong';
+    }
+}

--- a/tests/common/HtmlTest.php
+++ b/tests/common/HtmlTest.php
@@ -438,6 +438,38 @@ final class HtmlTest extends TestCase
         $this->assertSame('<span><span>Hello</span></span>', Html::span(Html::span('Hello'))->render());
     }
 
+    public function testEm(): void
+    {
+        $this->assertSame('<em></em>', Html::em()->render());
+        $this->assertSame('<em>hello</em>', Html::em('hello')->render());
+        $this->assertSame('<em id="main">hello</em>', Html::em('hello', ['id' => 'main'])->render());
+        $this->assertSame('<em><span>Hello</span></em>', Html::em(Html::span('Hello'))->render());
+    }
+
+    public function testStrong(): void
+    {
+        $this->assertSame('<strong></strong>', Html::strong()->render());
+        $this->assertSame('<strong>hello</strong>', Html::strong('hello')->render());
+        $this->assertSame('<strong id="main">hello</strong>', Html::strong('hello', ['id' => 'main'])->render());
+        $this->assertSame('<strong><span>Hello</span></strong>', Html::strong(Html::span('Hello'))->render());
+    }
+
+    public function testB(): void
+    {
+        $this->assertSame('<b></b>', Html::b()->render());
+        $this->assertSame('<b>hello</b>', Html::b('hello')->render());
+        $this->assertSame('<b id="main">hello</b>', Html::b('hello', ['id' => 'main'])->render());
+        $this->assertSame('<b><span>Hello</span></b>', Html::b(Html::span('Hello'))->render());
+    }
+
+    public function testI(): void
+    {
+        $this->assertSame('<i></i>', Html::i()->render());
+        $this->assertSame('<i>hello</i>', Html::i('hello')->render());
+        $this->assertSame('<i id="main">hello</i>', Html::i('hello', ['id' => 'main'])->render());
+        $this->assertSame('<i><span>Hello</span></i>', Html::i(Html::span('Hello'))->render());
+    }
+
     public function testP(): void
     {
         $this->assertSame('<p></p>', Html::p()->render());

--- a/tests/common/Tag/BTest.php
+++ b/tests/common/Tag/BTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\B;
+
+final class BTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<b class="red">Hello</b>',
+            (string)B::tag()->class('red')->content('Hello')
+        );
+    }
+}

--- a/tests/common/Tag/EmTest.php
+++ b/tests/common/Tag/EmTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Em;
+
+final class EmTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<em class="red">Hello</em>',
+            (string)Em::tag()->class('red')->content('Hello')
+        );
+    }
+}

--- a/tests/common/Tag/ITest.php
+++ b/tests/common/Tag/ITest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\I;
+
+final class ITest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<i class="red">Hello</i>',
+            (string)I::tag()->class('red')->content('Hello')
+        );
+    }
+}

--- a/tests/common/Tag/StrongTest.php
+++ b/tests/common/Tag/StrongTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Strong;
+
+final class StrongTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<strong class="red">Hello</strong>',
+            (string)Strong::tag()->class('red')->content('Hello')
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -

Add popular tags that convenient to use via `Html::b()`, `Html::em()`, etc.
