### PR TITLE
Add methods `as()` and `preload()` to the `Link` tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.2.1 under development
 
 - Enh #74: Add classes for tags `Em`, `Strong`, `B` and `I` (vjik)
+- Enh #75: Add methods `as()` and `preload()` to the `Link` tag (vjik)
 
 ## 1.2.0 May 04, 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,20 @@
 
 ## 1.2.1 under development
 
-- Enh #74: Add classes for tags `Em`, `Strong`, `B` and `I` (vjik)
-- Enh #75: Add methods `as()` and `preload()` to the `Link` tag (vjik)
+- New #74: Add classes for tags `Em`, `Strong`, `B` and `I` (vjik)
+- New #75: Add methods `as()` and `preload()` to the `Link` tag (vjik)
 
 ## 1.2.0 May 04, 2021
 
-- Enh #70: Add support `\Stringable` as content in methods `Html::tag()`, `Html::normalTag()`, `Html::a()`,
+- New #70: Add support `\Stringable` as content in methods `Html::tag()`, `Html::normalTag()`, `Html::a()`,
   `Html::label()`, `Html::option()`, `Html::div()`, `Html::span()`, `Html::p()`, `Html::li()`, `Html::caption()`,
   `Html::td()`, `Html::th()` (vjik)
-- Enh #71: Add methods `Script::getContent()` and `Style::getContent()` (vjik)
+- New #71: Add methods `Script::getContent()` and `Style::getContent()` (vjik)
 
 ## 1.1.0 April 09, 2021
 
-- Enh #65: Add classes for table tags `Table`, `Caption`, `Colgroup`, `Col`, `Thead`, `Tbody`, `Tfoot`, `Tr`, `Th`, `Td` (vjik)
-- Enh #69: Add class for tag `Br` (vjik)
+- New #65: Add classes for table tags `Table`, `Caption`, `Colgroup`, `Col`, `Thead`, `Tbody`, `Tfoot`, `Tr`, `Th`, `Td` (vjik)
+- New #69: Add class for tag `Br` (vjik)
 
 ## 1.0.1 April 04, 2021
 

--- a/src/Tag/Link.php
+++ b/src/Tag/Link.php
@@ -77,6 +77,31 @@ final class Link extends VoidTag
         return $new;
     }
 
+    /**
+     * @link https://www.w3.org/TR/preload/#as-attribute
+     */
+    public function as(?string $value): self
+    {
+        $new = clone $this;
+        $new->attributes['as'] = $value;
+        return $new;
+    }
+
+    /**
+     * @link https://www.w3.org/TR/preload/#link-type-preload
+     * @link https://www.w3.org/TR/preload/#as-attribute
+     */
+    public function preload(string $url, string $as = null): self
+    {
+        $new = clone $this;
+        $new->attributes['rel'] = 'preload';
+        $new->attributes['href'] = $url;
+        if ($as !== null) {
+            $new->attributes['as'] = $as;
+        }
+        return $new;
+    }
+
     protected function getName(): string
     {
         return 'link';

--- a/tests/common/Tag/LinkTest.php
+++ b/tests/common/Tag/LinkTest.php
@@ -110,6 +110,43 @@ final class LinkTest extends TestCase
         $this->assertSame($expected, (string)Link::tag()->crossOrigin($crossOrigin));
     }
 
+    public function dataTestAs(): array
+    {
+        return [
+            ['<link>', null],
+            ['<link as="">', ''],
+            ['<link as="video">', 'video'],
+        ];
+    }
+
+    /**
+     * @dataProvider dataTestAs
+     */
+    public function testAs(string $expected, ?string $as): void
+    {
+        $this->assertSame($expected, (string)Link::tag()->as($as));
+    }
+
+    public function dataPreload(): array
+    {
+        return [
+            ['<link href="/main.css" rel="preload">', '/main.css'],
+            ['<link href="/main.css" rel="preload" as="style">', '/main.css', 'style'],
+        ];
+    }
+
+    /**
+     * @dataProvider dataPreload
+     */
+    public function testPreload(string $expected, string $url, string $as = null): void
+    {
+        $tag = $as === null
+            ? Link::tag()->preload($url)
+            : Link::tag()->preload($url, $as);
+
+        $this->assertSame($expected, $tag->render());
+    }
+
     public function testImmutability(): void
     {
         $link = Link::tag();
@@ -119,5 +156,7 @@ final class LinkTest extends TestCase
         $this->assertNotSame($link, $link->type(null));
         $this->assertNotSame($link, $link->title(null));
         $this->assertNotSame($link, $link->crossOrigin(null));
+        $this->assertNotSame($link, $link->as(null));
+        $this->assertNotSame($link, $link->preload(''));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -