### PR TITLE
Allow pass `null` argument to methods `Tag::class()`, `Tag::replaceClass()`, `BooleanInputTag::label()` and   `BooleanInputTag::sideLabel()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - New #74: Add classes for tags `Em`, `Strong`, `B` and `I` (vjik)
 - New #75: Add methods `as()` and `preload()` to the `Link` tag (vjik)
+- New #78: Allow pass `null` argument to methods `Tag::class()` and `Tag::replaceClass()` (vjik)
 
 ## 1.2.0 May 04, 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Yii HTML Change Log
 
-## 1.2.1 under development
+## 1.3.0 under development
 
 - New #74: Add classes for tags `Em`, `Strong`, `B` and `I` (vjik)
 - New #75: Add methods `as()` and `preload()` to the `Link` tag (vjik)
-- New #78: Allow pass `null` argument to methods `Tag::class()` and `Tag::replaceClass()` (vjik)
+- New #78: Allow pass `null` argument to methods `Tag::class()`, `Tag::replaceClass()`, `BooleanInputTag::label()` and
+  `BooleanInputTag::sideLabel()` (vjik)
 
 ## 1.2.0 May 04, 2021
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "maglnet/composer-require-checker": "^3.3",
         "phpunit/phpunit": "^9.5",
-        "roave/infection-static-analysis-plugin": "^1.8",
+        "roave/infection-static-analysis-plugin": "^1.9",
         "spatie/phpunit-watcher": "^1.23",
         "vimeo/psalm": "^4.8"
     },

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
         "yiisoft/json": "^1.0"
     },
     "require-dev": {
-        "maglnet/composer-require-checker": "^3.2",
+        "maglnet/composer-require-checker": "^3.3",
         "phpunit/phpunit": "^9.5",
-        "roave/infection-static-analysis-plugin": "^1.7",
+        "roave/infection-static-analysis-plugin": "^1.8",
         "spatie/phpunit-watcher": "^1.23",
-        "vimeo/psalm": "^4.7"
+        "vimeo/psalm": "^4.8"
     },
     "autoload": {
         "psr-4": {

--- a/src/Html.php
+++ b/src/Html.php
@@ -1156,7 +1156,10 @@ final class Html
                     if (empty($value)) {
                         continue;
                     }
-                    /** @psalm-var array<string, string> $value */
+                    /**
+                     * @psalm-suppress UnnecessaryVarAnnotation
+                     * @psalm-var array<string, string> $value
+                     */
                     $html .= " $name=\"" . self::encodeAttribute(self::cssStyleFromArray($value)) . '"';
                 } else {
                     $html .= " $name='" . Json::htmlEncode($value) . "'";

--- a/src/Tag/Base/BooleanInputTag.php
+++ b/src/Tag/Base/BooleanInputTag.php
@@ -35,12 +35,12 @@ abstract class BooleanInputTag extends InputTag
     /**
      * Label that is wraps around attribute when rendered.
      *
-     * @param string $label Input label.
+     * @param string|null $label Input label.
      * @param array $attributes Name-value set of label attributes.
      *
      * @return static
      */
-    final public function label(string $label, array $attributes = []): self
+    final public function label(?string $label, array $attributes = []): self
     {
         $new = clone $this;
         $new->label = $label;
@@ -51,12 +51,12 @@ abstract class BooleanInputTag extends InputTag
     /**
      * Label that is rendered separately and is referring input by ID.
      *
-     * @param string $label Input label.
+     * @param string|null $label Input label.
      * @param array $attributes Name-value set of label attributes.
      *
      * @return static
      */
-    final public function sideLabel(string $label, array $attributes = []): self
+    final public function sideLabel(?string $label, array $attributes = []): self
     {
         $new = clone $this;
         $new->label = $label;
@@ -96,7 +96,9 @@ abstract class BooleanInputTag extends InputTag
 
     final protected function before(): string
     {
-        $this->attributes['id'] ??= $this->labelWrap ? null : Html::generateId();
+        $this->attributes['id'] ??= ($this->labelWrap || $this->label === null)
+            ? null
+            : Html::generateId();
 
         return $this->renderUncheckInput() .
             ($this->labelWrap ? $this->renderLabelOpenTag($this->labelAttributes) : '');
@@ -141,13 +143,13 @@ abstract class BooleanInputTag extends InputTag
             return '';
         }
 
-        $html = ' ';
-
-        if (!$this->labelWrap) {
+        if ($this->labelWrap) {
+            $html = $this->label === '' ? '' : ' ';
+        } else {
             $labelAttributes = array_merge($this->labelAttributes, [
                 'for' => $this->attributes['id'],
             ]);
-            $html .= $this->renderLabelOpenTag($labelAttributes);
+            $html = ' ' . $this->renderLabelOpenTag($labelAttributes);
         }
 
         $html .= $this->labelEncode ? Html::encode($this->label) : $this->label;

--- a/src/Tag/Base/Tag.php
+++ b/src/Tag/Base/Tag.php
@@ -75,15 +75,18 @@ abstract class Tag implements NoEncodeStringableInterface
     /**
      * Add one or more CSS classes to the tag.
      *
-     * @param string ...$class One or many CSS classes.
+     * @param string|null ...$class One or many CSS classes.
      *
      * @return static
      */
-    final public function class(string ...$class): self
+    final public function class(?string ...$class): self
     {
         $new = clone $this;
         /** @psalm-suppress MixedArgumentTypeCoercion */
-        Html::addCssClass($new->attributes, $class);
+        Html::addCssClass(
+            $new->attributes,
+            array_filter($class, static fn($c) => $c !== null),
+        );
         return $new;
     }
 

--- a/src/Tag/Base/Tag.php
+++ b/src/Tag/Base/Tag.php
@@ -85,7 +85,7 @@ abstract class Tag implements NoEncodeStringableInterface
         /** @psalm-suppress MixedArgumentTypeCoercion */
         Html::addCssClass(
             $new->attributes,
-            array_filter($class, static fn($c) => $c !== null),
+            array_filter($class, static fn ($c) => $c !== null),
         );
         return $new;
     }
@@ -100,7 +100,7 @@ abstract class Tag implements NoEncodeStringableInterface
     final public function replaceClass(?string ...$class): self
     {
         $new = clone $this;
-        $new->attributes['class'] = array_filter($class, static fn($c) => $c !== null);
+        $new->attributes['class'] = array_filter($class, static fn ($c) => $c !== null);
         return $new;
     }
 

--- a/src/Tag/Base/Tag.php
+++ b/src/Tag/Base/Tag.php
@@ -93,14 +93,14 @@ abstract class Tag implements NoEncodeStringableInterface
     /**
      * Replace current tag CSS classes with a new set of classes.
      *
-     * @param string ...$class One or many CSS classes.
+     * @param string|null ...$class One or many CSS classes.
      *
      * @return static
      */
-    final public function replaceClass(string ...$class): self
+    final public function replaceClass(?string ...$class): self
     {
         $new = clone $this;
-        $new->attributes['class'] = $class;
+        $new->attributes['class'] = array_filter($class, static fn($c) => $c !== null);
         return $new;
     }
 

--- a/tests/common/Tag/Base/BooleanInputTagTest.php
+++ b/tests/common/Tag/Base/BooleanInputTagTest.php
@@ -34,13 +34,23 @@ final class BooleanInputTagTest extends TestCase
                 'One',
                 ['class' => 'red'],
             ],
+            [
+                '<label><input type="test"></label>',
+                '',
+                [],
+            ],
+            [
+                '<input type="test">',
+                null,
+                [],
+            ],
         ];
     }
 
     /**
      * @dataProvider dataLabel
      */
-    public function testLabel(string $expected, string $label, array $attributes): void
+    public function testLabel(string $expected, ?string $label, array $attributes): void
     {
         $this->assertSame(
             $expected,
@@ -61,6 +71,22 @@ final class BooleanInputTagTest extends TestCase
         $this->assertMatchesRegularExpression(
             '~<input type="test" id="i(\d*?)"> <label for="i\1">One</label>~',
             TestBooleanInputTag::tag()->sideLabel('One')->render()
+        );
+    }
+
+    public function testSideLabelEmpty(): void
+    {
+        $this->assertMatchesRegularExpression(
+            '~<input type="test" id="i(\d*?)"> <label for="i\1"></label>~',
+            TestBooleanInputTag::tag()->sideLabel('')->render()
+        );
+    }
+
+    public function testSideLabelNull(): void
+    {
+        $this->assertSame(
+            '<input type="test">',
+            TestBooleanInputTag::tag()->sideLabel(null)->render()
         );
     }
 

--- a/tests/common/Tag/Base/TagTest.php
+++ b/tests/common/Tag/Base/TagTest.php
@@ -20,6 +20,8 @@ final class TagTest extends TestCase
                 '<test checked disabled required="yes">',
                 ['checked' => true, 'disabled' => true, 'hidden' => false, 'required' => 'yes'],
             ],
+            ['<test class="">', ['class' => '']],
+            ['<test class="red">', ['class' => 'red']],
             ['<test class="first second">', ['class' => ['first', 'second']]],
             ['<test>', ['class' => []]],
             ['<test style="width: 100px; height: 200px;">', ['style' => ['width' => '100px', 'height' => '200px']]],
@@ -139,6 +141,23 @@ final class TagTest extends TestCase
     public function testClass(string $expected, array $class): void
     {
         $this->assertSame($expected, (string)TestTag::tag()->class('main')->class(...$class));
+    }
+
+    public function dataNewClass(): array
+    {
+        return [
+            ['<test>', null],
+            ['<test class="">', ''],
+            ['<test class="red">', 'red'],
+        ];
+    }
+
+    /**
+     * @dataProvider dataNewClass
+     */
+    public function testNewClass(string $expected, ?string $class): void
+    {
+        $this->assertSame($expected, (string)TestTag::tag()->class($class));
     }
 
     public function dataReplaceClass(): array

--- a/tests/common/Tag/Base/TagTest.php
+++ b/tests/common/Tag/Base/TagTest.php
@@ -164,6 +164,8 @@ final class TagTest extends TestCase
     {
         return [
             ['<test>', []],
+            ['<test>', [null]],
+            ['<test class="">', ['']],
             ['<test class="main">', ['main']],
             ['<test class="main bold">', ['main bold']],
             ['<test class="main bold">', ['main', 'bold']],
@@ -177,7 +179,7 @@ final class TagTest extends TestCase
      */
     public function testReplaceClass(string $expected, array $class): void
     {
-        $this->assertSame($expected, (string)TestTag::tag()->replaceClass(...$class));
+        $this->assertSame($expected, (string)TestTag::tag()->class('red')->replaceClass(...$class));
     }
 
     public function testImmutability(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -

Also update dev dependencies and fix psalm errors