### PR TITLE
For attributes with empty string value generated only attribute name without value and character `=`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - New #75: Add methods `as()` and `preload()` to the `Link` tag (vjik)
 - New #78: Allow pass `null` argument to methods `Tag::class()`, `Tag::replaceClass()`, `BooleanInputTag::label()` and
   `BooleanInputTag::sideLabel()` (vjik)
+- Chg #79: For attributes with empty string value generated only attribute name without value and character `=` (vjik)
 
 ## 1.2.0 May 04, 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Yii HTML Change Log
 
-## 1.3.0 under development
+## 2.0.0 under development
 
 - New #74: Add classes for tags `Em`, `Strong`, `B` and `I` (vjik)
 - New #75: Add methods `as()` and `preload()` to the `Link` tag (vjik)

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,16 @@
         "irc": "irc://irc.freenode.net/yii",
         "source": "https://github.com/yiisoft/html"
     },
+    "funding": [
+        {
+            "type": "opencollective",
+            "url": "https://opencollective.com/yiisoft"
+        },
+        {
+            "type": "github",
+            "url": "https://github.com/sponsors/yiisoft"
+        }
+    ],
     "require": {
         "php": "^7.4|^8.0",
         "yiisoft/arrays": "^1.0",
@@ -24,7 +34,7 @@
         "phpunit/phpunit": "^9.5",
         "roave/infection-static-analysis-plugin": "^1.9",
         "spatie/phpunit-watcher": "^1.23",
-        "vimeo/psalm": "^4.8"
+        "vimeo/psalm": "^4.9"
     },
     "autoload": {
         "psr-4": {

--- a/src/Html.php
+++ b/src/Html.php
@@ -1131,39 +1131,40 @@ final class Html
         }
 
         $html = '';
-        /** @var mixed */
+        /**
+         * @var string $name
+         * @var mixed $value
+         */
         foreach ($attributes as $name => $value) {
             if (is_bool($value)) {
                 if ($value) {
-                    $html .= " $name";
+                    $html .= self::renderAttribute($name);
                 }
             } elseif (is_array($value)) {
                 if (in_array($name, self::DATA_ATTRIBUTES, true)) {
                     /** @psalm-var array<array-key, array|string|\Stringable|null> $value */
                     foreach ($value as $n => $v) {
-                        if (is_array($v)) {
-                            $html .= " $name-$n='" . Json::htmlEncode($v) . "'";
-                        } else {
-                            $html .= " $name-$n=\"" . self::encodeAttribute($v) . '"';
-                        }
+                        $html .= is_array($v)
+                            ? self::renderAttribute($name . '-' . $n, Json::htmlEncode($v), '\'')
+                            : self::renderAttribute($name . '-' . $n, self::encodeAttribute($v));
                     }
                 } elseif ($name === 'class') {
                     /** @var string[] $value */
                     if (empty($value)) {
                         continue;
                     }
-                    $html .= " $name=\"" . self::encodeAttribute(implode(' ', $value)) . '"';
+                    $html .= self::renderAttribute($name, self::encodeAttribute(implode(' ', $value)));
                 } elseif ($name === 'style') {
                     /** @psalm-var array<string,string> $value */
                     if (empty($value)) {
                         continue;
                     }
-                    $html .= " $name=\"" . self::encodeAttribute(self::cssStyleFromArray($value)) . '"';
+                    $html .= self::renderAttribute($name, self::encodeAttribute(self::cssStyleFromArray($value)));
                 } else {
-                    $html .= " $name='" . Json::htmlEncode($value) . "'";
+                    $html .= self::renderAttribute($name, Json::htmlEncode($value), '\'');
                 }
             } elseif ($value !== null) {
-                $html .= " $name=\"" . self::encodeAttribute($value) . '"';
+                $html .= self::renderAttribute($name, self::encodeAttribute($value));
             }
         }
 
@@ -1445,5 +1446,20 @@ final class Html
     public static function getNonArrayableName(string $name): string
     {
         return substr($name, -2) === '[]' ? substr($name, 0, -2) : $name;
+    }
+
+    /**
+     * Render attribute in HTML tag.
+     *
+     * @link https://html.spec.whatwg.org/#a-quick-introduction-to-html
+     */
+    private static function renderAttribute(string $name, string $encodedValue = '', string $quote = '"'): string
+    {
+        // The value, along with the "=" character, can be omitted altogether if the value is the empty string.
+        if ($encodedValue === '') {
+            return ' ' . $name;
+        }
+
+        return ' ' . $name . '=' . $quote . $encodedValue . $quote;
     }
 }

--- a/src/Html.php
+++ b/src/Html.php
@@ -1148,6 +1148,7 @@ final class Html
                         }
                     }
                 } elseif ($name === 'class') {
+                    /** @var string[] $value */
                     if (empty($value)) {
                         continue;
                     }
@@ -1229,6 +1230,7 @@ final class Html
                     $options['class'] = $classes;
                 }
             } else {
+                /** @var string[] */
                 $classes = preg_split('/\s+/', (string)$options['class'], -1, PREG_SPLIT_NO_EMPTY);
                 $classes = array_diff($classes, (array)$class);
                 if (empty($classes)) {

--- a/src/Html.php
+++ b/src/Html.php
@@ -1154,13 +1154,10 @@ final class Html
                     }
                     $html .= " $name=\"" . self::encodeAttribute(implode(' ', $value)) . '"';
                 } elseif ($name === 'style') {
+                    /** @psalm-var array<string,string> $value */
                     if (empty($value)) {
                         continue;
                     }
-                    /**
-                     * @psalm-suppress UnnecessaryVarAnnotation
-                     * @psalm-var array<string, string> $value
-                     */
                     $html .= " $name=\"" . self::encodeAttribute(self::cssStyleFromArray($value)) . '"';
                 } else {
                     $html .= " $name='" . Json::htmlEncode($value) . "'";

--- a/src/Tag/Base/ListTag.php
+++ b/src/Tag/Base/ListTag.php
@@ -11,6 +11,9 @@ use Yiisoft\Html\Tag\Li;
  */
 abstract class ListTag extends NormalTag
 {
+    /**
+     * @var Li[]
+     */
     private array $items = [];
 
     /**

--- a/src/Tag/Base/TableRowsContainerTag.php
+++ b/src/Tag/Base/TableRowsContainerTag.php
@@ -8,6 +8,9 @@ use Yiisoft\Html\Tag\Tr;
 
 abstract class TableRowsContainerTag extends NormalTag
 {
+    /**
+     * @var Tr[]
+     */
     private array $rows = [];
 
     /**

--- a/src/Tag/Base/Tag.php
+++ b/src/Tag/Base/Tag.php
@@ -82,7 +82,6 @@ abstract class Tag implements NoEncodeStringableInterface
     final public function class(?string ...$class): self
     {
         $new = clone $this;
-        /** @psalm-suppress MixedArgumentTypeCoercion */
         Html::addCssClass(
             $new->attributes,
             array_filter($class, static fn ($c) => $c !== null),

--- a/src/Tag/Colgroup.php
+++ b/src/Tag/Colgroup.php
@@ -11,6 +11,9 @@ use Yiisoft\Html\Tag\Base\NormalTag;
  */
 final class Colgroup extends NormalTag
 {
+    /**
+     * @var Col[]
+     */
     private array $columns = [];
 
     /**

--- a/src/Tag/Tr.php
+++ b/src/Tag/Tr.php
@@ -12,6 +12,9 @@ use Yiisoft\Html\Tag\Base\TableCellTag;
  */
 final class Tr extends NormalTag
 {
+    /**
+     * @var TableCellTag[]
+     */
     private array $items = [];
 
     /**

--- a/tests/common/HtmlTest.php
+++ b/tests/common/HtmlTest.php
@@ -127,7 +127,7 @@ final class HtmlTest extends TestCase
     public function testLink(): void
     {
         $this->assertSame('<link>', Html::link()->render());
-        $this->assertSame('<link href="">', Html::link('')->render());
+        $this->assertSame('<link href>', Html::link('')->render());
         $this->assertSame('<link href="main.css">', Html::link('main.css')->render());
         $this->assertSame(
             '<link id="main" href="main.css">',
@@ -142,7 +142,7 @@ final class HtmlTest extends TestCase
             Html::cssFile('http://example.com')->render()
         );
         $this->assertSame(
-            '<link href="" rel="stylesheet">',
+            '<link href rel="stylesheet">',
             Html::cssFile('')->render()
         );
         $this->assertSame(
@@ -158,7 +158,7 @@ final class HtmlTest extends TestCase
             Html::javaScriptFile('http://example.com')->render()
         );
         $this->assertSame(
-            '<script src=""></script>',
+            '<script src></script>',
             Html::javaScriptFile('')->render()
         );
         $this->assertSame(
@@ -197,8 +197,8 @@ final class HtmlTest extends TestCase
 
     public function testImg(): void
     {
-        $this->assertSame('<img alt="">', Html::img()->render());
-        $this->assertSame('<img src="" alt="">', Html::img('')->render());
+        $this->assertSame('<img alt>', Html::img()->render());
+        $this->assertSame('<img src alt>', Html::img('')->render());
         $this->assertSame('<img>', Html::img(null, null)->render());
         $this->assertSame('<img src="face.png" alt="My Face">', Html::img('face.png', 'My Face')->render());
     }
@@ -207,7 +207,7 @@ final class HtmlTest extends TestCase
     {
         $this->assertSame('<label></label>', Html::label()->render());
         $this->assertSame('<label>Name</label>', Html::label('Name')->render());
-        $this->assertSame('<label for="">Name</label>', Html::label('Name', '')->render());
+        $this->assertSame('<label for>Name</label>', Html::label('Name', '')->render());
         $this->assertSame('<label for="fieldName">Name</label>', Html::label('Name', 'fieldName')->render());
         $this->assertSame('<label><span>Hello</span></label>', Html::label(Html::span('Hello'))->render());
     }
@@ -250,10 +250,10 @@ final class HtmlTest extends TestCase
 
     public function testInput(): void
     {
-        $this->assertSame('<input type="">', Html::input('')->render());
+        $this->assertSame('<input type>', Html::input('')->render());
         $this->assertSame('<input type="text">', Html::input('text')->render());
-        $this->assertSame('<input type="text" name="">', Html::input('text', '')->render());
-        $this->assertSame('<input type="text" value="">', Html::input('text', null, '')->render());
+        $this->assertSame('<input type="text" name>', Html::input('text', '')->render());
+        $this->assertSame('<input type="text" value>', Html::input('text', null, '')->render());
         $this->assertSame('<input type="text" name="test">', Html::input('text', 'test')->render());
         $this->assertSame(
             '<input type="text" name="test" value="43">',
@@ -265,7 +265,7 @@ final class HtmlTest extends TestCase
     {
         $this->assertSame('<input type="button" value="Button">', Html::buttonInput()->render());
         $this->assertSame('<input type="button">', Html::buttonInput(null)->render());
-        $this->assertSame('<input type="button" value="">', Html::buttonInput('')->render());
+        $this->assertSame('<input type="button" value>', Html::buttonInput('')->render());
         $this->assertSame('<input type="button" value="Go">', Html::buttonInput('Go')->render());
     }
 
@@ -273,7 +273,7 @@ final class HtmlTest extends TestCase
     {
         $this->assertSame('<input type="submit" value="Submit">', Html::submitInput()->render());
         $this->assertSame('<input type="submit">', Html::submitInput(null)->render());
-        $this->assertSame('<input type="submit" value="">', Html::submitInput('')->render());
+        $this->assertSame('<input type="submit" value>', Html::submitInput('')->render());
         $this->assertSame('<input type="submit" value="Go">', Html::submitInput('Go')->render());
     }
 
@@ -281,15 +281,15 @@ final class HtmlTest extends TestCase
     {
         $this->assertSame('<input type="reset" value="Reset">', Html::resetInput()->render());
         $this->assertSame('<input type="reset">', Html::resetInput(null)->render());
-        $this->assertSame('<input type="reset" value="">', Html::resetInput('')->render());
+        $this->assertSame('<input type="reset" value>', Html::resetInput('')->render());
         $this->assertSame('<input type="reset" value="Go">', Html::resetInput('Go')->render());
     }
 
     public function testTextInput(): void
     {
         $this->assertSame('<input type="text">', Html::textInput()->render());
-        $this->assertSame('<input type="text" name="">', Html::textInput('')->render());
-        $this->assertSame('<input type="text" value="">', Html::textInput(null, '')->render());
+        $this->assertSame('<input type="text" name>', Html::textInput('')->render());
+        $this->assertSame('<input type="text" value>', Html::textInput(null, '')->render());
         $this->assertSame('<input type="text" name="test">', Html::textInput('test')->render());
         $this->assertSame(
             '<input type="text" name="test" value="43">',
@@ -300,8 +300,8 @@ final class HtmlTest extends TestCase
     public function testHiddenInput(): void
     {
         $this->assertSame('<input type="hidden">', Html::hiddenInput()->render());
-        $this->assertSame('<input type="hidden" name="">', Html::hiddenInput('')->render());
-        $this->assertSame('<input type="hidden" value="">', Html::hiddenInput(null, '')->render());
+        $this->assertSame('<input type="hidden" name>', Html::hiddenInput('')->render());
+        $this->assertSame('<input type="hidden" value>', Html::hiddenInput(null, '')->render());
         $this->assertSame('<input type="hidden" name="test">', Html::hiddenInput('test')->render());
         $this->assertSame(
             '<input type="hidden" name="test" value="43">',
@@ -312,8 +312,8 @@ final class HtmlTest extends TestCase
     public function testPasswordInput(): void
     {
         $this->assertSame('<input type="password">', Html::passwordInput()->render());
-        $this->assertSame('<input type="password" name="">', Html::passwordInput('')->render());
-        $this->assertSame('<input type="password" value="">', Html::passwordInput(null, '')->render());
+        $this->assertSame('<input type="password" name>', Html::passwordInput('')->render());
+        $this->assertSame('<input type="password" value>', Html::passwordInput(null, '')->render());
         $this->assertSame('<input type="password" name="test">', Html::passwordInput('test')->render());
         $this->assertSame(
             '<input type="password" name="test" value="43">',
@@ -324,8 +324,8 @@ final class HtmlTest extends TestCase
     public function testFileInput(): void
     {
         $this->assertSame('<input type="file">', Html::fileInput()->render());
-        $this->assertSame('<input type="file" name="">', Html::fileInput('')->render());
-        $this->assertSame('<input type="file" value="">', Html::fileInput(null, '')->render());
+        $this->assertSame('<input type="file" name>', Html::fileInput('')->render());
+        $this->assertSame('<input type="file" value>', Html::fileInput(null, '')->render());
         $this->assertSame('<input type="file" name="test">', Html::fileInput('test')->render());
         $this->assertSame(
             '<input type="file" name="test" value="43">',
@@ -336,8 +336,8 @@ final class HtmlTest extends TestCase
     public function testRadio(): void
     {
         $this->assertSame('<input type="radio">', Html::radio()->render());
-        $this->assertSame('<input type="radio" name="">', Html::radio('')->render());
-        $this->assertSame('<input type="radio" value="">', Html::radio(null, '')->render());
+        $this->assertSame('<input type="radio" name>', Html::radio('')->render());
+        $this->assertSame('<input type="radio" value>', Html::radio(null, '')->render());
         $this->assertSame('<input type="radio" name="test">', Html::radio('test')->render());
         $this->assertSame(
             '<input type="radio" name="test" value="43">',
@@ -348,8 +348,8 @@ final class HtmlTest extends TestCase
     public function testCheckbox(): void
     {
         $this->assertSame('<input type="checkbox">', Html::checkbox()->render());
-        $this->assertSame('<input type="checkbox" name="">', Html::checkbox('')->render());
-        $this->assertSame('<input type="checkbox" value="">', Html::checkbox(null, '')->render());
+        $this->assertSame('<input type="checkbox" name>', Html::checkbox('')->render());
+        $this->assertSame('<input type="checkbox" value>', Html::checkbox(null, '')->render());
         $this->assertSame('<input type="checkbox" name="test">', Html::checkbox('test')->render());
         $this->assertSame(
             '<input type="checkbox" name="test" value="43">',
@@ -360,7 +360,7 @@ final class HtmlTest extends TestCase
     public function testSelect(): void
     {
         $this->assertSame('<select></select>', Html::select()->render());
-        $this->assertSame('<select name=""></select>', Html::select('')->render());
+        $this->assertSame('<select name></select>', Html::select('')->render());
         $this->assertSame('<select name="test"></select>', Html::select('test')->render());
     }
 
@@ -372,7 +372,7 @@ final class HtmlTest extends TestCase
     public function testOption(): void
     {
         $this->assertSame('<option></option>', Html::option()->render());
-        $this->assertSame('<option value=""></option>', Html::option('', '')->render());
+        $this->assertSame('<option value></option>', Html::option('', '')->render());
         $this->assertSame('<option>test</option>', Html::option('test')->render());
         $this->assertSame('<option value="42">test</option>', Html::option('test', 42)->render());
         $this->assertSame('<option><span>Hello</span></option>', Html::option(Html::span('Hello'))->render());
@@ -381,7 +381,7 @@ final class HtmlTest extends TestCase
     public function testTextarea(): void
     {
         $this->assertSame('<textarea></textarea>', Html::textarea()->render());
-        $this->assertSame('<textarea name=""></textarea>', Html::textarea('')->render());
+        $this->assertSame('<textarea name></textarea>', Html::textarea('')->render());
         $this->assertSame('<textarea name="test"></textarea>', Html::textarea('test')->render());
         $this->assertSame('<textarea name="test">body</textarea>', Html::textarea('test', 'body')->render());
     }

--- a/tests/common/Tag/Base/InputTagTest.php
+++ b/tests/common/Tag/Base/InputTagTest.php
@@ -54,7 +54,7 @@ final class InputTagTest extends TestCase
     {
         return [
             ['<input>', null],
-            ['<input form="">', ''],
+            ['<input form>', ''],
             ['<input form="post">', 'post'],
         ];
     }

--- a/tests/common/Tag/Base/TagTest.php
+++ b/tests/common/Tag/Base/TagTest.php
@@ -20,7 +20,7 @@ final class TagTest extends TestCase
                 '<test checked disabled required="yes">',
                 ['checked' => true, 'disabled' => true, 'hidden' => false, 'required' => 'yes'],
             ],
-            ['<test class="">', ['class' => '']],
+            ['<test class>', ['class' => '']],
             ['<test class="red">', ['class' => 'red']],
             ['<test class="first second">', ['class' => ['first', 'second']]],
             ['<test>', ['class' => []]],
@@ -147,7 +147,7 @@ final class TagTest extends TestCase
     {
         return [
             ['<test>', null],
-            ['<test class="">', ''],
+            ['<test class>', ''],
             ['<test class="red">', 'red'],
         ];
     }
@@ -165,7 +165,7 @@ final class TagTest extends TestCase
         return [
             ['<test>', []],
             ['<test>', [null]],
-            ['<test class="">', ['']],
+            ['<test class>', ['']],
             ['<test class="main">', ['main']],
             ['<test class="main bold">', ['main bold']],
             ['<test class="main bold">', ['main', 'bold']],

--- a/tests/common/Tag/LinkTest.php
+++ b/tests/common/Tag/LinkTest.php
@@ -114,7 +114,7 @@ final class LinkTest extends TestCase
     {
         return [
             ['<link>', null],
-            ['<link as="">', ''],
+            ['<link as>', ''],
             ['<link as="video">', 'video'],
         ];
     }

--- a/tests/common/Tag/MetaTest.php
+++ b/tests/common/Tag/MetaTest.php
@@ -56,7 +56,7 @@ final class MetaTest extends TestCase
     {
         return [
             ['<meta>', null],
-            ['<meta name="">', ''],
+            ['<meta name>', ''],
             ['<meta name="keywords">', 'keywords'],
         ];
     }
@@ -73,7 +73,7 @@ final class MetaTest extends TestCase
     {
         return [
             ['<meta>', null],
-            ['<meta http-equiv="">', ''],
+            ['<meta http-equiv>', ''],
             ['<meta http-equiv="refresh">', 'refresh'],
         ];
     }
@@ -90,7 +90,7 @@ final class MetaTest extends TestCase
     {
         return [
             ['<meta>', null],
-            ['<meta content="">', ''],
+            ['<meta content>', ''],
             ['<meta content="Yii">', 'Yii'],
         ];
     }
@@ -107,7 +107,7 @@ final class MetaTest extends TestCase
     {
         return [
             ['<meta>', null],
-            ['<meta charset="">', ''],
+            ['<meta charset>', ''],
             ['<meta charset="utf-8">', 'utf-8'],
         ];
     }

--- a/tests/common/Tag/SelectTest.php
+++ b/tests/common/Tag/SelectTest.php
@@ -35,14 +35,14 @@ final class SelectTest extends TestCase
     {
         return [
             ['<select multiple></select>', null],
-            ['<select name="" multiple></select>', ''],
+            ['<select name multiple></select>', ''],
             [
-                '<input type="hidden" name="age" value="">' . "\n" .
+                '<input type="hidden" name="age" value>' . "\n" .
                 '<select name="age[]" multiple></select>',
                 'age',
             ],
             [
-                '<input type="hidden" name="place" value="">' . "\n" .
+                '<input type="hidden" name="place" value>' . "\n" .
                 '<select name="place[]" multiple></select>',
                 'place[]',
             ],
@@ -164,7 +164,7 @@ final class SelectTest extends TestCase
     {
         return [
             ['<select></select>', null],
-            ['<select form=""></select>', ''],
+            ['<select form></select>', ''],
             ['<select form="post"></select>', 'post'],
         ];
     }
@@ -275,7 +275,7 @@ final class SelectTest extends TestCase
             ],
             [
                 '<select>' . "\n" .
-                '<option value="">Please select...</option>' . "\n" .
+                '<option value>Please select...</option>' . "\n" .
                 '<option value="1">One</option>' . "\n" .
                 '</select>',
                 'Please select...',

--- a/tests/common/Tag/TextareaTest.php
+++ b/tests/common/Tag/TextareaTest.php
@@ -87,7 +87,7 @@ final class TextareaTest extends TestCase
     {
         return [
             ['<textarea></textarea>', null],
-            ['<textarea form=""></textarea>', ''],
+            ['<textarea form></textarea>', ''],
             ['<textarea form="post"></textarea>', 'post'],
         ];
     }

--- a/tests/common/Widget/CheckboxListTest.php
+++ b/tests/common/Widget/CheckboxListTest.php
@@ -254,8 +254,8 @@ final class CheckboxListTest extends TestCase
             ],
             [
                 '<div>' . "\n" .
-                '<label><input type="checkbox" name="test[]" value="1" form=""> One</label>' . "\n" .
-                '<label><input type="checkbox" name="test[]" value="2" form=""> Two</label>' . "\n" .
+                '<label><input type="checkbox" name="test[]" value="1" form> One</label>' . "\n" .
+                '<label><input type="checkbox" name="test[]" value="2" form> Two</label>' . "\n" .
                 '</div>',
                 '',
             ],

--- a/tests/common/Widget/RadioListTest.php
+++ b/tests/common/Widget/RadioListTest.php
@@ -224,8 +224,8 @@ final class RadioListTest extends TestCase
             ],
             [
                 '<div>' . "\n" .
-                '<label><input type="radio" name="test" value="1" form=""> One</label>' . "\n" .
-                '<label><input type="radio" name="test" value="2" form=""> Two</label>' . "\n" .
+                '<label><input type="radio" name="test" value="1" form> One</label>' . "\n" .
+                '<label><input type="radio" name="test" value="2" form> Two</label>' . "\n" .
                 '</div>',
                 '',
             ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #79 
