### PR TITLE
Add `NoEncode` class designed to use as non-encoded content in HTML tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - New #75: Add methods `as()` and `preload()` to the `Link` tag (vjik)
 - New #78: Allow pass `null` argument to methods `Tag::class()`, `Tag::replaceClass()`, `BooleanInputTag::label()` and
   `BooleanInputTag::sideLabel()` (vjik)
-- New #76: Add `NoEncode` class designed to use as non-encoded content in HTML tags (vjik)
+- New #76: Add `NoEncode` class designed to wrap content that should not be encoded in HTML tags (vjik)
 
 ## 1.2.0 May 04, 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - New #75: Add methods `as()` and `preload()` to the `Link` tag (vjik)
 - New #78: Allow pass `null` argument to methods `Tag::class()`, `Tag::replaceClass()`, `BooleanInputTag::label()` and
   `BooleanInputTag::sideLabel()` (vjik)
+- New #76: Add `NoEncode` class designed to use as non-encoded content in HTML tags (vjik)
 
 ## 1.2.0 May 04, 2021
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The package provides:
   `Caption`, `Colgroup`, `Col`, `Thead`, `Tbody`, `Tfoot`, `Tr`, `Th`, `Td`;
 - `CustomTag` class that helps to generate custom tag with any attributes;
 - HTML widgets `CheckboxList` and `RadioList`;
-- `NoEncode` class is designed for use as non-encoded content in HTML tags;
+- `NoEncode` class is designed to wrap content that should not be encoded in HTML tags;
 - `Html` helper that has static methods to generate HTML, create tag and HTML widget objects.
 
 ## Requirements
@@ -112,17 +112,18 @@ echo \Yiisoft\Html\Tag\CustomTag::name('b')
 <b title="Important">text</b>
 ```
 
-### Encoding content of tags
+### Encoding tags content
 
-Encoding behavior for tag content by default: stringable objects that implement
-interface `\Yiisoft\Html\NoEncodeStringableInterface` are not encoded, everything else is encoded.
+By default, stringable objects that implement `\Yiisoft\Html\NoEncodeStringableInterface` are not encoded,
+everything else is encoded.
 
-For change this behavior use method `encode()`, which supported values:
+To change this behavior use `encode()` method passing one of the following values:
 - `null`: default behavior;
 - `true`: any content is encoded;
 - `false`: nothing is encoded.
  
-> Note: all tags and widgets implemented the `\Yiisoft\Html\NoEncodeStringableInterface` interface and not encoded by default.
+> Note: all bundled tags and widgets implement `\Yiisoft\Html\NoEncodeStringableInterface` interface and are not encoded
+> by default when passed as content. Their own content is encoded.
 
 Examples:
 
@@ -140,7 +141,7 @@ echo Html::b(Html::i('hello'));
 echo Html::b(Html::i('hello'))->encode(true);
 ```
 
-Additional method for not encode string in tag content is using of the `\Yiisoft\Html\NoEncode` class:
+In order to mark a string as "do not encode" you can use `\Yiisoft\Html\NoEncode` class:
 
 ```php
 // <b><i>hello</i></b>

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ For change this behavior use method `encode()`, which supported values:
 Examples:
 
 ```php
-// <b>&amp;lt;i&amp;gt;hello&amp;lt;/i&amp;gt;</b>
+// <b>&lt;i&gt;hello&lt;/i&gt;</b>
 echo Html::b('<i>hello</i>');
 
 // <b><i>hello</i></b>
@@ -136,7 +136,7 @@ echo Html::b('<i>hello</i>')->encode(false);
 // <b><i>hello</i></b>
 echo Html::b(Html::i('hello'));
 
-// <b>&amp;lt;i&amp;gt;hello&amp;lt;/i&amp;gt;</b>
+// <b>&lt;i&gt;hello&lt;/i&gt;</b>
 echo Html::b(Html::i('hello'))->encode(true);
 ```
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ For change this behavior use method `encode()`, which supported values:
 - `true`: any content is encoded;
 - `false`: nothing is encoded.
  
-> Note: all tag objects implemented the `\Yiisoft\Html\NoEncodeStringableInterface` interface and not encoded by default.
+> Note: all tags and widgets implemented the `\Yiisoft\Html\NoEncodeStringableInterface` interface and not encoded by default.
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ For change this behavior use method `encode()`, which supported values:
 - `true`: any content is encoded;
 - `false`: nothing is encoded.
  
-> Note: all tag objects implemented the `\Yiisoft\Html\NoEncodeStringableInterface` interface and not encoded.
+> Note: all tag objects implemented the `\Yiisoft\Html\NoEncodeStringableInterface` interface and not encoded by default.
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ echo Html::b(Html::i('hello'));
 echo Html::b(Html::i('hello'))->encode(true);
 ```
 
-Additional method for not encode string in tag content is using of the `NoEncode` class:
+Additional method for not encode string in tag content is using of the `\Yiisoft\Html\NoEncode` class:
 
 ```php
 // <b><i>hello</i></b>

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The package provides:
   `Caption`, `Colgroup`, `Col`, `Thead`, `Tbody`, `Tfoot`, `Tr`, `Th`, `Td`;
 - `CustomTag` class that helps to generate custom tag with any attributes;
 - HTML widgets `CheckboxList` and `RadioList`;
+- `NoEncode` class is designed for use as non-encoded content in HTML tags;
 - `Html` helper that has static methods to generate HTML, create tag and HTML widget objects.
 
 ## Requirements
@@ -109,6 +110,41 @@ echo \Yiisoft\Html\Tag\CustomTag::name('b')
 
 ```html
 <b title="Important">text</b>
+```
+
+### Encoding content of tags
+
+Encoding behavior for tag content by default: stringable objects that implement
+interface `\Yiisoft\Html\NoEncodeStringableInterface` are not encoded, everything else is encoded.
+
+For change this behavior use method `encode()`, which supported values:
+- `null`: default behavior;
+- `true`: any content is encoded;
+- `false`: nothing is encoded.
+ 
+> Note: all tag objects implemented the `\Yiisoft\Html\NoEncodeStringableInterface` interface and not encoded.
+
+Examples:
+
+```php
+// <b>&amp;lt;i&amp;gt;hello&amp;lt;/i&amp;gt;</b>
+echo Html::b('<i>hello</i>');
+
+// <b><i>hello</i></b>
+echo Html::b('<i>hello</i>')->encode(false);
+
+// <b><i>hello</i></b>
+echo Html::b(Html::i('hello'));
+
+// <b>&amp;lt;i&amp;gt;hello&amp;lt;/i&amp;gt;</b>
+echo Html::b(Html::i('hello'))->encode(true);
+```
+
+Additional method for not encode string in tag content is using of the `NoEncode` class:
+
+```php
+// <b><i>hello</i></b>
+echo Html::b(NoEncode::string('<i>hello</i>'));
 ```
 
 ## HTML widgets usage

--- a/src/NoEncode.php
+++ b/src/NoEncode.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html;
+
+final class NoEncode implements NoEncodeStringableInterface
+{
+    private string $string;
+
+    private function __construct(string $string)
+    {
+        $this->string = $string;
+    }
+
+    public static function string(string $value): self
+    {
+        return new self($value);
+    }
+
+    public function __toString(): string
+    {
+        return $this->string;
+    }
+}

--- a/src/NoEncode.php
+++ b/src/NoEncode.php
@@ -4,6 +4,15 @@ declare(strict_types=1);
 
 namespace Yiisoft\Html;
 
+/**
+ * The `NoEncode` class is designed for use as non-encoded content in HTML tags.
+ * For example:
+ *
+ * ```php
+ * // Will be printed "<b><i>hello</i></b>"
+ * echo Html:b(NoEncode::string('<i>hello</i>'));
+ * ```
+ */
 final class NoEncode implements NoEncodeStringableInterface
 {
     private string $string;

--- a/src/NoEncode.php
+++ b/src/NoEncode.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Yiisoft\Html;
 
 /**
- * The `NoEncode` class is designed for use as non-encoded content in HTML tags.
+ * The `NoEncode` class is designed to wrap content that should not be encoded in HTML tags.
  * For example:
  *
  * ```php
- * // Will be printed "<b><i>hello</i></b>"
+ * // The following will produce "<b><i>hello</i></b>"
  * echo Html:b(NoEncode::string('<i>hello</i>'));
  * ```
  */

--- a/tests/common/NoEncodeTest.php
+++ b/tests/common/NoEncodeTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\NoEncode;
+use Yiisoft\Html\NoEncodeStringableInterface;
+
+final class NoEncodeTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $object = NoEncode::string('test');
+
+        $this->assertInstanceOf(NoEncodeStringableInterface::class, $object);
+        $this->assertSame('test', (string)$object);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #76

Psalm errors fixed in #80 

May be rename `NoEncode` to `AsIs`? Will be `AsIs::string('<i>hello</i>')`.