### PR TITLE
Fix order attributes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   `BooleanInputTag::sideLabel()` (vjik)
 - Chg #79: Do not add empty attribute value for empty strings (vjik)
 - New #76: Add `NoEncode` class designed to wrap content that should not be encoded in HTML tags (vjik)
+- Chg #83: Fix constant order `ATTRIBUTE_ORDER` html attributes. (terabytesoftw)
 
 ## 1.2.0 May 04, 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   `BooleanInputTag::sideLabel()` (vjik)
 - Chg #79: Do not add empty attribute value for empty strings (vjik)
 - New #76: Add `NoEncode` class designed to wrap content that should not be encoded in HTML tags (vjik)
-- Chg #83: Fix constant order `ATTRIBUTE_ORDER` html attributes. (terabytesoftw)
+- Bug #83: Fix `Html::ATTRIBUTE_ORDER` values (terabytesoftw)
 
 ## 1.2.0 May 04, 2021
 

--- a/src/Html.php
+++ b/src/Html.php
@@ -101,6 +101,7 @@ final class Html
 
         'size',
         'maxlength',
+        'minlength',
         'width',
         'height',
         'rows',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

Order correct:

```HTML
<input type="email" id="attributesvalidatorform-email" name="AttributesValidatorForm[email]" value="" maxlength="20" minlength="8" required>
```

Current Order: 

```HTML
<input type="email" id="attributesvalidatorform-email" name="AttributesValidatorForm[email]" value="" maxlength="20" required minlength="8">
```


The `minlength` attribute must be added since the validator `HasLength::class` adds it, it is also common to use it with `maxlength`. 