### PR TITLE
Add method `itemsAsValues()` to widgets `RadioList` and `CheckboxList` that set items with labels equal to values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.2.0 under development
 
-- New #90: Add method `itemsAsValues()` to widgets `RadioList` and `CheckboxList` that set items with labels equal
+- New #90: Add method `itemsFromValues()` to widgets `RadioList` and `CheckboxList` that set items with labels equal
   to values (vjik)
 - New #92: A third optional argument `$attributes` containing tag attributes in terms of name-value pairs has been
   added to methods `Html::textInput()`, `Html::hiddenInput()`, `Html::passwordInput()`, `Html::fileInput()`,

--- a/src/Widget/CheckboxList/CheckboxList.php
+++ b/src/Widget/CheckboxList/CheckboxList.php
@@ -131,10 +131,12 @@ final class CheckboxList implements NoEncodeStringableInterface
     }
 
     /**
+     * Fills items from an array provided. Array values are used for both input labels and input values.
+     *
      * @param bool[]|float[]|int[]|string[]|\Stringable[] $values
      * @param bool $encodeLabels Whether labels should be encoded.
      */
-    public function itemsAsValues(array $values, bool $encodeLabels = true): self
+    public function itemsFromValues(array $values, bool $encodeLabels = true): self
     {
         $values = array_map('\strval', $values);
 

--- a/src/Widget/RadioList/RadioList.php
+++ b/src/Widget/RadioList/RadioList.php
@@ -122,10 +122,12 @@ final class RadioList implements NoEncodeStringableInterface
     }
 
     /**
+     * Fills items from an array provided. Array values are used for both input labels and input values.
+     *
      * @param bool[]|float[]|int[]|string[]|\Stringable[] $values
      * @param bool $encodeLabels Whether labels should be encoded.
      */
-    public function itemsAsValues(array $values, bool $encodeLabels = true): self
+    public function itemsFromValues(array $values, bool $encodeLabels = true): self
     {
         $values = array_map('\strval', $values);
 

--- a/tests/common/Widget/CheckboxListTest.php
+++ b/tests/common/Widget/CheckboxListTest.php
@@ -255,7 +255,7 @@ final class CheckboxListTest extends TestCase
         );
     }
 
-    public function dataItemsAsValues(): array
+    public function dataItemsFromValues(): array
     {
         return [
             [
@@ -277,26 +277,26 @@ final class CheckboxListTest extends TestCase
     }
 
     /**
-     * @dataProvider dataItemsAsValues
+     * @dataProvider dataItemsFromValues
      */
-    public function testItemsAsValues(string $expected, array $values): void
+    public function testItemsFromValues(string $expected, array $values): void
     {
         $this->assertSame(
             $expected,
             CheckboxList::create('test')
-                ->itemsAsValues($values)
+                ->itemsFromValues($values)
                 ->withoutContainer()
                 ->render(),
         );
     }
 
-    public function testItemsAsValuesWithoutEncodeLabel(): void
+    public function testItemsFromValuesWithoutEncodeLabel(): void
     {
         $this->assertSame(
             '<label><input type="checkbox" name="test[]" value="One"> One</label>' . "\n" .
             '<label><input type="checkbox" name="test[]" value="&lt;b&gt;Two&lt;/b&gt;"> <b>Two</b></label>',
             CheckboxList::create('test')
-                ->itemsAsValues([
+                ->itemsFromValues([
                     'One',
                     '<b>Two</b>',
                 ], false)
@@ -642,7 +642,7 @@ final class CheckboxListTest extends TestCase
         $this->assertNotSame($widget, $widget->individualInputAttributes([]));
         $this->assertNotSame($widget, $widget->replaceIndividualInputAttributes([]));
         $this->assertNotSame($widget, $widget->items([]));
-        $this->assertNotSame($widget, $widget->itemsAsValues([]));
+        $this->assertNotSame($widget, $widget->itemsFromValues([]));
         $this->assertNotSame($widget, $widget->value());
         $this->assertNotSame($widget, $widget->values([]));
         $this->assertNotSame($widget, $widget->form(''));

--- a/tests/common/Widget/RadioListTest.php
+++ b/tests/common/Widget/RadioListTest.php
@@ -252,7 +252,7 @@ final class RadioListTest extends TestCase
         );
     }
 
-    public function dataItemsAsValues(): array
+    public function dataItemsFromValues(): array
     {
         return [
             [
@@ -274,26 +274,26 @@ final class RadioListTest extends TestCase
     }
 
     /**
-     * @dataProvider dataItemsAsValues
+     * @dataProvider dataItemsFromValues
      */
-    public function testItemsAsValues(string $expected, array $values): void
+    public function testItemsFromValues(string $expected, array $values): void
     {
         $this->assertSame(
             $expected,
             RadioList::create('test')
-                ->itemsAsValues($values)
+                ->itemsFromValues($values)
                 ->withoutContainer()
                 ->render(),
         );
     }
 
-    public function testItemsAsValuesWithoutEncodeLabel(): void
+    public function testItemsFromValuesWithoutEncodeLabel(): void
     {
         $this->assertSame(
             '<label><input type="radio" name="test" value="One"> One</label>' . "\n" .
             '<label><input type="radio" name="test" value="&lt;b&gt;Two&lt;/b&gt;"> <b>Two</b></label>',
             RadioList::create('test')
-                ->itemsAsValues([
+                ->itemsFromValues([
                     'One',
                     '<b>Two</b>',
                 ], false)
@@ -612,7 +612,7 @@ final class RadioListTest extends TestCase
         $this->assertNotSame($widget, $widget->individualInputAttributes([]));
         $this->assertNotSame($widget, $widget->replaceIndividualInputAttributes([]));
         $this->assertNotSame($widget, $widget->items([]));
-        $this->assertNotSame($widget, $widget->itemsAsValues([]));
+        $this->assertNotSame($widget, $widget->itemsFromValues([]));
         $this->assertNotSame($widget, $widget->value(null));
         $this->assertNotSame($widget, $widget->form(''));
         $this->assertNotSame($widget, $widget->readonly());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -
