### PR TITLE
extend NoEncodeStringableInterface from Stringable interface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
+        "symfony/polyfill-php80": "^1.25",
         "yiisoft/arrays": "^1.0|^2.0",
         "yiisoft/json": "^1.0"
     },

--- a/src/NoEncodeStringableInterface.php
+++ b/src/NoEncodeStringableInterface.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Html;
 /**
  * An object that could be cast to string that should not be HTML-encoded when used.
  */
-interface NoEncodeStringableInterface
+interface NoEncodeStringableInterface extends \Stringable
 {
     public function __toString(): string;
 }

--- a/tests/common/NoEncodeTest.php
+++ b/tests/common/NoEncodeTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Html\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Stringable;
 use Yiisoft\Html\NoEncode;
 use Yiisoft\Html\NoEncodeStringableInterface;
 
@@ -14,7 +15,10 @@ final class NoEncodeTest extends TestCase
     {
         $object = NoEncode::string('test');
 
+        $this->assertInstanceOf(Stringable::class, $object);
         $this->assertInstanceOf(NoEncodeStringableInterface::class, $object);
         $this->assertSame('test', (string)$object);
+        $this->assertTrue(is_a($object, Stringable::class));
+        $this->assertTrue(is_a($object, NoEncodeStringableInterface::class));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

With this update it is possible to use `is_a($htmlLibObject, \Stringable::class)` checks for the objects of this library.

Idea came from here:
https://github.com/yiisoft/yii-bootstrap5/pull/85#issuecomment-1086122114