### PR TITLE
Add option groups support to method `Select::optionsData()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.3.1 under development
 
-- no changes in this release.
+- Enh #106: Add option groups support to method `Select::optionsData()` (vjik)
 
 ## 2.3.0 March 25, 2022
 

--- a/src/Tag/Select.php
+++ b/src/Tag/Select.php
@@ -99,21 +99,29 @@ final class Select extends NormalTag
     }
 
     /**
-     * @param string[] $data
+     * @param array $data
      * @param bool $encode Whether option content should be HTML-encoded.
+     *
+     * @psalm-param array<array-key, string|array<array-key,string>> $data
      *
      * @return self
      */
     public function optionsData(array $data, bool $encode = true): self
     {
-        $options = [];
+        $items = [];
         foreach ($data as $value => $content) {
-            $options[] = Option::tag()
-                ->value($value)
-                ->content($content)
-                ->encode($encode);
+            if (is_array($content)) {
+                $items[] = Optgroup::tag()
+                    ->label((string)$value)
+                    ->optionsData($content, $encode);
+            } else {
+                $items[] = Option::tag()
+                    ->value((string)$value)
+                    ->content($content)
+                    ->encode($encode);
+            }
         }
-        return $this->items(...$options);
+        return $this->items(...$items);
     }
 
     /**

--- a/tests/common/Support/AssertTrait.php
+++ b/tests/common/Support/AssertTrait.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Support;
+
+use PHPUnit\Framework\Constraint\StringContains;
+use PHPUnit\Framework\ExpectationFailedException;
+
+trait AssertTrait
+{
+    /**
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
+     */
+    public function assertStringContainsStringIgnoringLineEndings(
+        string $needle,
+        string $haystack,
+        string $message = ''
+    ): void {
+        $needle = $this->normalizeLineEndings($needle);
+        $haystack = $this->normalizeLineEndings($haystack);
+
+        static::assertThat($haystack, new StringContains($needle, false), $message);
+    }
+
+    private function normalizeLineEndings(string $value): string
+    {
+        return strtr($value, [
+            "\r\n" => "\n",
+            "\r" => "\n",
+        ]);
+    }
+}

--- a/tests/common/Tag/SelectTest.php
+++ b/tests/common/Tag/SelectTest.php
@@ -11,9 +11,12 @@ use Yiisoft\Html\Tag\Li;
 use Yiisoft\Html\Tag\Optgroup;
 use Yiisoft\Html\Tag\Option;
 use Yiisoft\Html\Tag\Select;
+use Yiisoft\Html\Tests\Support\AssertTrait;
 
 final class SelectTest extends TestCase
 {
+    use AssertTrait;
+
     public function dataName(): array
     {
         return [
@@ -261,6 +264,31 @@ final class SelectTest extends TestCase
         $this->assertSame(
             "<select>\n<option value=\"1\"><b>One</b></option>\n</select>",
             (string)Select::tag()->optionsData(['1' => '<b>One</b>'], false)
+        );
+    }
+
+    public function testOptionsDataWithGroups(): void
+    {
+        $tag = Select::tag()
+            ->optionsData([
+                1 => 'One',
+                'Test Group' => [
+                    2 => 'Two',
+                    3 => 'Three',
+                ],
+            ]);
+
+        $this->assertStringContainsStringIgnoringLineEndings(
+            <<<HTML
+            <select>
+            <option value="1">One</option>
+            <optgroup label="Test Group">
+            <option value="2">Two</option>
+            <option value="3">Three</option>
+            </optgroup>
+            </select>
+            HTML,
+            $tag->render()
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -
