### PR TITLE
Add `$attributes` to `Html` methods `input()`, `buttonInput()`, `submitInput()` and `resetInput()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Enh #106: Add option groups support to method `Select::optionsData()` (vjik)
 - Enh #108: Add individual attributes of options and option groups support to method `Select::optionsData()` (vjik)
 - Enh #102: Remove psalm type `HtmlAttributes`, too obsessive for package users (vjik)
+- Enh #104: Add parameter `$attributes` to methods `Html::input()`, `Html::buttonInput()`, `Html::submitInput()` 
+  and `Html::resetInput()` (vjik)
 
 ## 2.3.0 March 25, 2022
 

--- a/src/Html.php
+++ b/src/Html.php
@@ -632,8 +632,9 @@ final class Html
      * @param string|null $name The name attribute. If it is `null`, the name attribute will not be generated.
      * @param bool|float|int|string|Stringable|null $value The value attribute. If it is `null`, the value
      * attribute will not be generated.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function input(string $type, ?string $name = null, $value = null): Input
+    public static function input(string $type, ?string $name = null, $value = null, array $attributes = []): Input
     {
         $tag = Input::tag()->type($type);
         if ($name !== null) {
@@ -641,6 +642,9 @@ final class Html
         }
         if ($value !== null) {
             $tag = $tag->value($value);
+        }
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
         }
         return $tag;
     }
@@ -651,10 +655,15 @@ final class Html
      * @see Input::button()
      *
      * @param string|null $label The value attribute.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function buttonInput(?string $label = 'Button'): Input
+    public static function buttonInput(?string $label = 'Button', array $attributes = []): Input
     {
-        return Input::button($label);
+        $tag = Input::button($label);
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $tag;
     }
 
     /**
@@ -663,10 +672,15 @@ final class Html
      * @see Input::submitButton()
      *
      * @param string|null $label The value attribute.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function submitInput(?string $label = 'Submit'): Input
+    public static function submitInput(?string $label = 'Submit', array $attributes = []): Input
     {
-        return Input::submitButton($label);
+        $tag = Input::submitButton($label);
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $tag;
     }
 
     /**
@@ -675,10 +689,15 @@ final class Html
      * @see Input::resetButton()
      *
      * @param string|null $label The value attribute.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function resetInput(?string $label = 'Reset'): Input
+    public static function resetInput(?string $label = 'Reset', array $attributes = []): Input
     {
-        return Input::resetButton($label);
+        $tag = Input::resetButton($label);
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $tag;
     }
 
     /**

--- a/tests/common/HtmlTest.php
+++ b/tests/common/HtmlTest.php
@@ -297,6 +297,10 @@ final class HtmlTest extends TestCase
             '<input type="text" name="test" value="43">',
             Html::input('text', 'test', '43')->render(),
         );
+        $this->assertSame(
+            '<input type="text" name="test" value="43" data-key="x101">',
+            Html::input('text', 'test', '43', ['data-key' => 'x101'])->render(),
+        );
     }
 
     public function testButtonInput(): void
@@ -305,6 +309,10 @@ final class HtmlTest extends TestCase
         $this->assertSame('<input type="button">', Html::buttonInput(null)->render());
         $this->assertSame('<input type="button" value>', Html::buttonInput('')->render());
         $this->assertSame('<input type="button" value="Go">', Html::buttonInput('Go')->render());
+        $this->assertSame(
+            '<input type="button" value="Go" data-key="x101">',
+            Html::buttonInput('Go', ['data-key' => 'x101'])->render(),
+        );
     }
 
     public function testSubmitInput(): void
@@ -313,6 +321,10 @@ final class HtmlTest extends TestCase
         $this->assertSame('<input type="submit">', Html::submitInput(null)->render());
         $this->assertSame('<input type="submit" value>', Html::submitInput('')->render());
         $this->assertSame('<input type="submit" value="Go">', Html::submitInput('Go')->render());
+        $this->assertSame(
+            '<input type="submit" value="Go" data-key="x101">',
+            Html::submitInput('Go', ['data-key' => 'x101'])->render(),
+        );
     }
 
     public function testResetInput(): void
@@ -321,6 +333,10 @@ final class HtmlTest extends TestCase
         $this->assertSame('<input type="reset">', Html::resetInput(null)->render());
         $this->assertSame('<input type="reset" value>', Html::resetInput('')->render());
         $this->assertSame('<input type="reset" value="Go">', Html::resetInput('Go')->render());
+        $this->assertSame(
+            '<input type="reset" value="Go" data-key="x101">',
+            Html::resetInput('Go', ['data-key' => 'x101'])->render(),
+        );
     }
 
     public function testTextInput(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #104 
