### PR TITLE
Allow use `CheckboxList` and `RadioList` widgets without name attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Enh #102: Remove psalm type `HtmlAttributes`, too obsessive for package users (vjik)
 - Enh #104: Add parameter `$attributes` to methods `Html::input()`, `Html::buttonInput()`, `Html::submitInput()` 
   and `Html::resetInput()` (vjik)
+- Enh #114: Allow use `CheckboxList` and `RadioList` widgets without name attribute (vjik)
 
 ## 2.3.0 March 25, 2022
 

--- a/src/Widget/CheckboxList/CheckboxItem.php
+++ b/src/Widget/CheckboxList/CheckboxItem.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Yiisoft\Html\Widget\CheckboxList;
 
+use Stringable;
+
 final class CheckboxItem
 {
     public int $index;
-    public string $name;
+    public ?string $name;
 
     /**
-     * @var bool|float|int|string|\Stringable|null
+     * @var bool|float|int|string|Stringable|null
      */
     public $value;
 
@@ -20,11 +22,11 @@ final class CheckboxItem
     public bool $encodeLabel;
 
     /**
-     * @param bool|float|int|string|\Stringable|null $value
+     * @param bool|float|int|string|Stringable|null $value
      */
     public function __construct(
         int $index,
-        string $name,
+        ?string $name,
         $value,
         bool $checked,
         array $checkboxAttributes,

--- a/src/Widget/CheckboxList/CheckboxList.php
+++ b/src/Widget/CheckboxList/CheckboxList.php
@@ -6,6 +6,7 @@ namespace Yiisoft\Html\Widget\CheckboxList;
 
 use Closure;
 use InvalidArgumentException;
+use Stringable;
 use Yiisoft\Arrays\ArrayHelper;
 use Yiisoft\Html\Html;
 use Yiisoft\Html\NoEncodeStringableInterface;
@@ -36,10 +37,7 @@ final class CheckboxList implements NoEncodeStringableInterface
      */
     private array $items = [];
 
-    /**
-     * @psalm-param non-empty-string
-     */
-    private string $name;
+    private ?string $name;
 
     /**
      * @psalm-var list<string>
@@ -51,12 +49,12 @@ final class CheckboxList implements NoEncodeStringableInterface
      */
     private ?Closure $itemFormatter = null;
 
-    private function __construct(string $name)
+    private function __construct(?string $name)
     {
         $this->name = $name;
     }
 
-    public static function create(string $name): self
+    public static function create(?string $name = null): self
     {
         return new self($name);
     }
@@ -133,7 +131,7 @@ final class CheckboxList implements NoEncodeStringableInterface
     /**
      * Fills items from an array provided. Array values are used for both input labels and input values.
      *
-     * @param bool[]|float[]|int[]|string[]|\Stringable[] $values
+     * @param bool[]|float[]|int[]|string[]|Stringable[] $values
      * @param bool $encodeLabels Whether labels should be encoded.
      */
     public function itemsFromValues(array $values, bool $encodeLabels = true): self
@@ -147,7 +145,7 @@ final class CheckboxList implements NoEncodeStringableInterface
     }
 
     /**
-     * @param scalar|\Stringable ...$value
+     * @param scalar|Stringable ...$value
      */
     public function value(...$value): self
     {
@@ -157,7 +155,7 @@ final class CheckboxList implements NoEncodeStringableInterface
     }
 
     /**
-     * @psalm-param iterable<int, \Stringable|scalar> $values
+     * @psalm-param iterable<int, Stringable|scalar> $values
      */
     public function values($values): self
     {
@@ -166,7 +164,7 @@ final class CheckboxList implements NoEncodeStringableInterface
             throw new InvalidArgumentException('$values should be iterable.');
         }
 
-        /** @psalm-var iterable<int, \Stringable|scalar> $values */
+        /** @psalm-var iterable<int, Stringable|scalar> $values */
         $values = is_array($values) ? $values : iterator_to_array($values);
 
         return $this->value(...$values);
@@ -203,7 +201,7 @@ final class CheckboxList implements NoEncodeStringableInterface
     }
 
     /**
-     * @param bool|float|int|string|\Stringable|null $value
+     * @param bool|float|int|string|Stringable|null $value
      */
     public function uncheckValue($value): self
     {
@@ -233,7 +231,9 @@ final class CheckboxList implements NoEncodeStringableInterface
 
     public function render(): string
     {
-        $name = Html::getArrayableName($this->name);
+        $name = $this->name === null
+            ? null
+            : Html::getArrayableName($this->name);
 
         $lines = [];
         $index = 0;
@@ -276,7 +276,7 @@ final class CheckboxList implements NoEncodeStringableInterface
     {
         return
             Input::hidden(
-                Html::getNonArrayableName($this->name),
+                $this->name === null ? null : Html::getNonArrayableName($this->name),
                 $this->uncheckValue
             )
                 ->attributes(

--- a/src/Widget/RadioList/RadioItem.php
+++ b/src/Widget/RadioList/RadioItem.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Yiisoft\Html\Widget\RadioList;
 
+use Stringable;
+
 final class RadioItem
 {
     public int $index;
-    public string $name;
+    public ?string $name;
 
     /**
-     * @var bool|float|int|string|\Stringable|null
+     * @var bool|float|int|string|Stringable|null
      */
     public $value;
 
@@ -20,11 +22,11 @@ final class RadioItem
     public bool $encodeLabel;
 
     /**
-     * @param bool|float|int|string|\Stringable|null $value
+     * @param bool|float|int|string|Stringable|null $value
      */
     public function __construct(
         int $index,
-        string $name,
+        ?string $name,
         $value,
         bool $checked,
         array $radioAttributes,

--- a/src/Widget/RadioList/RadioList.php
+++ b/src/Widget/RadioList/RadioList.php
@@ -32,10 +32,7 @@ final class RadioList implements NoEncodeStringableInterface
      */
     private array $items = [];
 
-    /**
-     * @psalm-param non-empty-string
-     */
-    private string $name;
+    private ?string $name;
 
     private ?string $value = null;
 
@@ -44,12 +41,12 @@ final class RadioList implements NoEncodeStringableInterface
      */
     private ?Closure $itemFormatter = null;
 
-    private function __construct(string $name)
+    private function __construct(?string $name)
     {
         $this->name = $name;
     }
 
-    public static function create(string $name): self
+    public static function create(?string $name = null): self
     {
         return new self($name);
     }
@@ -249,7 +246,7 @@ final class RadioList implements NoEncodeStringableInterface
     {
         return
             Input::hidden(
-                Html::getNonArrayableName($this->name),
+                $this->name === null ? null : Html::getNonArrayableName($this->name),
                 $this->uncheckValue
             )
                 ->attributes(

--- a/tests/common/Widget/CheckboxListTest.php
+++ b/tests/common/Widget/CheckboxListTest.php
@@ -32,6 +32,24 @@ final class CheckboxListTest extends TestCase
         );
     }
 
+    public function testWithoutName(): void
+    {
+        $this->assertSame(
+            '<input type="hidden" value="0">' . "\n" .
+            '<div id="main">' . "\n" .
+            '<label><input type="checkbox" value="1"> One</label>' . "\n" .
+            '<label><input type="checkbox" value="2" checked> Two</label>' . "\n" .
+            '<label><input type="checkbox" value="5" checked> Five</label>' . "\n" .
+            '</div>',
+            CheckboxList::create()
+                ->items([1 => 'One', 2 => 'Two', 5 => 'Five'])
+                ->uncheckValue(0)
+                ->value(2, 5)
+                ->containerAttributes(['id' => 'main'])
+                ->render(),
+        );
+    }
+
     public function testWithoutContainer(): void
     {
         $this->assertSame(

--- a/tests/common/Widget/RadioListTest.php
+++ b/tests/common/Widget/RadioListTest.php
@@ -29,6 +29,24 @@ final class RadioListTest extends TestCase
         );
     }
 
+    public function testWithoutName(): void
+    {
+        $this->assertSame(
+            '<input type="hidden" value="0">' . "\n" .
+            '<div id="main">' . "\n" .
+            '<label><input type="radio" value="1"> One</label>' . "\n" .
+            '<label><input type="radio" value="2" checked> Two</label>' . "\n" .
+            '<label><input type="radio" value="5"> Five</label>' . "\n" .
+            '</div>',
+            RadioList::create()
+                ->items([1 => 'One', 2 => 'Two', 5 => 'Five'])
+                ->uncheckValue(0)
+                ->value(2)
+                ->containerAttributes(['id' => 'main'])
+                ->render(),
+        );
+    }
+
     public function testWithoutContainer(): void
     {
         $this->assertSame(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | -