### PR TITLE
Mark some methods as deprecated

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -290,7 +290,7 @@ final class Html
             $tag = $tag->content($content);
         }
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $tag;
     }
@@ -313,7 +313,7 @@ final class Html
             $tag = $tag->content($content);
         }
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $tag;
     }
@@ -332,7 +332,7 @@ final class Html
     {
         $tag = CustomTag::name($name)->void();
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $tag;
     }
@@ -375,7 +375,7 @@ final class Html
             $tag = $tag->content($content);
         }
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $tag;
     }
@@ -393,7 +393,7 @@ final class Html
             $tag = $tag->content($content);
         }
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $tag;
     }
@@ -419,7 +419,7 @@ final class Html
     {
         $tag = Title::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -433,7 +433,7 @@ final class Html
     {
         $tag = Meta::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $tag;
     }
@@ -451,7 +451,7 @@ final class Html
             $tag = $tag->url($url);
         }
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes, false);
         }
         return $tag;
     }
@@ -466,7 +466,7 @@ final class Html
     {
         $tag = Link::toCssFile($url);
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes, false);
         }
         return $tag;
     }
@@ -481,7 +481,7 @@ final class Html
     {
         $tag = Script::tag()->url($url);
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes, false);
         }
         return $tag;
     }
@@ -504,7 +504,7 @@ final class Html
             $tag = $tag->url($url);
         }
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes, false);
         }
         return $tag;
     }
@@ -522,7 +522,7 @@ final class Html
             ->content($content)
             ->mailto($mail ?? $content);
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes, false);
         }
         return $tag;
     }
@@ -554,7 +554,7 @@ final class Html
     {
         $tag = Fieldset::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $tag;
     }
@@ -576,7 +576,7 @@ final class Html
             $attributes['method'] = $method;
         }
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $tag;
     }
@@ -613,7 +613,7 @@ final class Html
             $tag = $tag->content($content);
         }
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $tag;
     }
@@ -630,7 +630,7 @@ final class Html
     {
         $tag = Button::button($content);
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes, false);
         }
         return $tag;
     }
@@ -647,7 +647,7 @@ final class Html
     {
         $tag = Button::submit($content);
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes, false);
         }
         return $tag;
     }
@@ -664,7 +664,7 @@ final class Html
     {
         $tag = Button::reset($content);
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes, false);
         }
         return $tag;
     }
@@ -688,7 +688,7 @@ final class Html
             $tag = $tag->value($value);
         }
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes, false);
         }
         return $tag;
     }
@@ -705,7 +705,7 @@ final class Html
     {
         $tag = Input::button($label);
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes, false);
         }
         return $tag;
     }
@@ -722,7 +722,7 @@ final class Html
     {
         $tag = Input::submitButton($label);
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes, false);
         }
         return $tag;
     }
@@ -739,7 +739,7 @@ final class Html
     {
         $tag = Input::resetButton($label);
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes, false);
         }
         return $tag;
     }
@@ -754,7 +754,7 @@ final class Html
     public static function textInput(?string $name = null, $value = null, array $attributes = []): Input
     {
         $tag = Input::text($name, $value);
-        return $attributes === [] ? $tag : $tag->attributes($attributes);
+        return $attributes === [] ? $tag : $tag->addAttributes($attributes, false);
     }
 
     /**
@@ -769,7 +769,7 @@ final class Html
     public static function hiddenInput(?string $name = null, $value = null, array $attributes = []): Input
     {
         $tag = Input::hidden($name, $value);
-        return $attributes === [] ? $tag : $tag->attributes($attributes);
+        return $attributes === [] ? $tag : $tag->addAttributes($attributes, false);
     }
 
     /**
@@ -784,7 +784,7 @@ final class Html
     public static function passwordInput(?string $name = null, $value = null, array $attributes = []): Input
     {
         $tag = Input::password($name, $value);
-        return $attributes === [] ? $tag : $tag->attributes($attributes);
+        return $attributes === [] ? $tag : $tag->addAttributes($attributes, false);
     }
 
     /**
@@ -805,7 +805,7 @@ final class Html
     public static function fileInput(?string $name = null, $value = null, array $attributes = []): Input
     {
         $tag = Input::file($name, $value);
-        return $attributes === [] ? $tag : $tag->attributes($attributes);
+        return $attributes === [] ? $tag : $tag->addAttributes($attributes, false);
     }
 
     /**
@@ -825,7 +825,7 @@ final class Html
     {
         /** @psalm-suppress DeprecatedMethod */
         $tag = Input::fileControl($name, $value);
-        return $attributes === [] ? $tag : $tag->attributes($attributes);
+        return $attributes === [] ? $tag : $tag->addAttributes($attributes, false);
     }
 
     /**
@@ -840,7 +840,7 @@ final class Html
     public static function radio(?string $name = null, $value = null, array $attributes = []): Radio
     {
         $tag = Input::radio($name, $value);
-        return $attributes === [] ? $tag : $tag->attributes($attributes);
+        return $attributes === [] ? $tag : $tag->addAttributes($attributes, false);
     }
 
     /**
@@ -855,7 +855,7 @@ final class Html
     public static function range(?string $name = null, $value = null, array $attributes = []): Range
     {
         $tag = Input::range($name, $value);
-        return $attributes === [] ? $tag : $tag->attributes($attributes);
+        return $attributes === [] ? $tag : $tag->addAttributes($attributes, false);
     }
 
     /**
@@ -870,7 +870,7 @@ final class Html
     public static function checkbox(?string $name = null, $value = null, array $attributes = []): Checkbox
     {
         $tag = Input::checkbox($name, $value);
-        return $attributes === [] ? $tag : $tag->attributes($attributes);
+        return $attributes === [] ? $tag : $tag->addAttributes($attributes, false);
     }
 
     /**
@@ -889,7 +889,7 @@ final class Html
         if (!empty($value)) {
             $tag = $tag->value($value);
         }
-        return $attributes === [] ? $tag : $tag->attributes($attributes);
+        return $attributes === [] ? $tag : $tag->addAttributes($attributes, false);
     }
 
     /**
@@ -962,7 +962,7 @@ final class Html
     {
         $tag = Div::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -977,7 +977,7 @@ final class Html
     {
         $tag = Span::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -992,7 +992,7 @@ final class Html
     {
         $tag = Em::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1007,7 +1007,7 @@ final class Html
     {
         $tag = Strong::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1022,7 +1022,7 @@ final class Html
     {
         $tag = B::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1037,7 +1037,7 @@ final class Html
     {
         $tag = I::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1052,7 +1052,7 @@ final class Html
     {
         $tag = H1::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1067,7 +1067,7 @@ final class Html
     {
         $tag = H2::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1082,7 +1082,7 @@ final class Html
     {
         $tag = H3::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1097,7 +1097,7 @@ final class Html
     {
         $tag = H4::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1112,7 +1112,7 @@ final class Html
     {
         $tag = H5::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1127,7 +1127,7 @@ final class Html
     {
         $tag = H6::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1142,7 +1142,7 @@ final class Html
     {
         $tag = P::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1184,7 +1184,7 @@ final class Html
     {
         $tag = Datalist::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $tag;
     }
@@ -1202,7 +1202,7 @@ final class Html
             $tag = $tag->content($content);
         }
         if ($attributes !== []) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $tag;
     }
@@ -1215,7 +1215,7 @@ final class Html
     public static function col(array $attributes = []): Col
     {
         $tag = Col::tag();
-        return $attributes === [] ? $tag : $tag->replaceAttributes($attributes);
+        return $attributes === [] ? $tag : $tag->addAttributes($attributes);
     }
 
     /**
@@ -1226,7 +1226,7 @@ final class Html
     public static function colgroup(array $attributes = []): Colgroup
     {
         $tag = Colgroup::tag();
-        return $attributes === [] ? $tag : $tag->replaceAttributes($attributes);
+        return $attributes === [] ? $tag : $tag->addAttributes($attributes);
     }
 
     /**
@@ -1237,7 +1237,7 @@ final class Html
     public static function table(array $attributes = []): Table
     {
         $tag = Table::tag();
-        return $attributes === [] ? $tag : $tag->replaceAttributes($attributes);
+        return $attributes === [] ? $tag : $tag->addAttributes($attributes);
     }
 
     /**
@@ -1248,7 +1248,7 @@ final class Html
     public static function thead(array $attributes = []): Thead
     {
         $tag = Thead::tag();
-        return $attributes === [] ? $tag : $tag->replaceAttributes($attributes);
+        return $attributes === [] ? $tag : $tag->addAttributes($attributes);
     }
 
     /**
@@ -1259,7 +1259,7 @@ final class Html
     public static function tbody(array $attributes = []): Tbody
     {
         $tag = Tbody::tag();
-        return $attributes === [] ? $tag : $tag->replaceAttributes($attributes);
+        return $attributes === [] ? $tag : $tag->addAttributes($attributes);
     }
 
     /**
@@ -1270,7 +1270,7 @@ final class Html
     public static function tfoot(array $attributes = []): Tfoot
     {
         $tag = Tfoot::tag();
-        return $attributes === [] ? $tag : $tag->replaceAttributes($attributes);
+        return $attributes === [] ? $tag : $tag->addAttributes($attributes);
     }
 
     /**
@@ -1281,7 +1281,7 @@ final class Html
     public static function tr(array $attributes = []): Tr
     {
         $tag = Tr::tag();
-        return $attributes === [] ? $tag : $tag->replaceAttributes($attributes);
+        return $attributes === [] ? $tag : $tag->addAttributes($attributes);
     }
 
     /**
@@ -1297,7 +1297,7 @@ final class Html
             $tag = $tag->content($content);
         }
         if ($attributes !== []) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $tag;
     }
@@ -1315,7 +1315,7 @@ final class Html
             $tag = $tag->content($content);
         }
         if ($attributes !== []) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $tag;
     }
@@ -1379,7 +1379,7 @@ final class Html
     {
         $tag = Body::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1394,7 +1394,7 @@ final class Html
     {
         $tag = Article::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1409,7 +1409,7 @@ final class Html
     {
         $tag = Section::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1424,7 +1424,7 @@ final class Html
     {
         $tag = Nav::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1439,7 +1439,7 @@ final class Html
     {
         $tag = Aside::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1454,7 +1454,7 @@ final class Html
     {
         $tag = Hgroup::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1469,7 +1469,7 @@ final class Html
     {
         $tag = Header::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1484,7 +1484,7 @@ final class Html
     {
         $tag = Footer::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1499,7 +1499,7 @@ final class Html
     {
         $tag = Address::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1788,7 +1788,7 @@ final class Html
     {
         $result = [];
         foreach (explode(';', (string)$style) as $property) {
-            $property = explode(':', $property);
+            $property = explode(':', $property, 2);
             if (count($property) > 1) {
                 $result[trim($property[0])] = trim($property[1]);
             }

--- a/src/Tag/Base/ListTag.php
+++ b/src/Tag/Base/ListTag.php
@@ -40,7 +40,7 @@ abstract class ListTag extends NormalTag
         $items = array_map(static function (string $string) use ($attributes, $encode) {
             return Li::tag()
                 ->content($string)
-                ->attributes($attributes)
+                ->addAttributes($attributes)
                 ->encode($encode);
         }, $strings);
         return $this->items(...$items);

--- a/src/Tag/Input/Range.php
+++ b/src/Tag/Input/Range.php
@@ -128,7 +128,7 @@ final class Range extends InputTag
         }
 
         return "\n" . CustomTag::name($this->outputTag)
-                ->attributes($this->outputAttributes)
+                ->addAttributes($this->outputAttributes)
                 ->content((string) ($this->attributes['value'] ?? '-'))
                 ->id($this->outputId)
                 ->render();

--- a/src/Tag/Optgroup.php
+++ b/src/Tag/Optgroup.php
@@ -37,7 +37,7 @@ final class Optgroup extends NormalTag
         $options = [];
         foreach ($data as $value => $content) {
             $options[] = Option::tag()
-                ->attributes($optionsAttributes[$value] ?? [])
+                ->addAttributes($optionsAttributes[$value] ?? [])
                 ->value($value)
                 ->content($content)
                 ->encode($encode);

--- a/src/Tag/Select.php
+++ b/src/Tag/Select.php
@@ -151,14 +151,14 @@ final class Select extends NormalTag
             if (is_array($content)) {
                 $items[] = Optgroup::tag()
                     ->label((string) $value)
-                    ->attributes($groupsAttributes[$value] ?? [])
-                    ->optionsData($content, $encode, $optionsAttributes);
+                    ->optionsData($content, $encode, $optionsAttributes)
+                    ->addAttributes($groupsAttributes[$value] ?? [], false);
             } else {
                 $items[] = Option::tag()
-                    ->attributes($optionsAttributes[$value] ?? [])
                     ->value($value)
                     ->content($content)
-                    ->encode($encode);
+                    ->encode($encode)
+                    ->addAttributes($optionsAttributes[$value] ?? [], false);
             }
         }
         return $this->items(...$items);

--- a/src/Tag/Tr.php
+++ b/src/Tag/Tr.php
@@ -67,7 +67,7 @@ final class Tr extends NormalTag
         return array_map(static function (string $string) use ($attributes, $encode) {
             return Td::tag()
                 ->content($string)
-                ->attributes($attributes)
+                ->addAttributes($attributes)
                 ->encode($encode);
         }, $strings);
     }
@@ -102,7 +102,7 @@ final class Tr extends NormalTag
         return array_map(static function (string $string) use ($attributes, $encode) {
             return Th::tag()
                 ->content($string)
-                ->attributes($attributes)
+                ->addAttributes($attributes)
                 ->encode($encode);
         }, $strings);
     }

--- a/src/Widget/CheckboxList/CheckboxList.php
+++ b/src/Widget/CheckboxList/CheckboxList.php
@@ -283,7 +283,7 @@ final class CheckboxList implements NoEncodeStringableInterface
                 Html::getNonArrayableName($this->name),
                 $this->uncheckValue
             )
-                ->attributes(
+                ->addAttributes(
                     array_merge(
                         [
                             // Make sure disabled input is not sending any value
@@ -291,7 +291,8 @@ final class CheckboxList implements NoEncodeStringableInterface
                             'form' => $this->checkboxAttributes['form'] ?? null,
                         ],
                         $this->individualInputAttributes[$this->uncheckValue] ?? []
-                    )
+                    ),
+                    false
                 )
                 ->render();
     }
@@ -302,8 +303,7 @@ final class CheckboxList implements NoEncodeStringableInterface
             return ($this->itemFormatter)($item);
         }
 
-        $checkbox = Html::checkbox($item->name, $item->value)
-            ->attributes($item->checkboxAttributes)
+        $checkbox = Html::checkbox($item->name, $item->value, $item->checkboxAttributes)
             ->checked($item->checked)
             ->label($item->label)
             ->labelEncode($item->encodeLabel);

--- a/src/Widget/RadioList/RadioList.php
+++ b/src/Widget/RadioList/RadioList.php
@@ -256,7 +256,7 @@ final class RadioList implements NoEncodeStringableInterface
                 Html::getNonArrayableName($this->name),
                 $this->uncheckValue
             )
-                ->attributes(
+                ->addAttributes(
                     array_merge(
                         [
                             // Make sure disabled input is not sending any value
@@ -264,7 +264,8 @@ final class RadioList implements NoEncodeStringableInterface
                             'form' => $this->radioAttributes['form'] ?? null,
                         ],
                         $this->individualInputAttributes[$this->uncheckValue] ?? []
-                    )
+                    ),
+                    false
                 )
                 ->render();
     }
@@ -275,8 +276,7 @@ final class RadioList implements NoEncodeStringableInterface
             return ($this->itemFormatter)($item);
         }
 
-        $radio = Html::radio($item->name, $item->value)
-            ->attributes($item->radioAttributes)
+        $radio = Html::radio($item->name, $item->value, $item->radioAttributes)
             ->checked($item->checked)
             ->label($item->label)
             ->labelEncode($item->encodeLabel);

--- a/tests/common/HtmlTest.php
+++ b/tests/common/HtmlTest.php
@@ -1179,6 +1179,29 @@ final class HtmlTest extends TestCase
             Html::address('Street 111, Mount View Town.', ['class' => 'red'])->render()
         );
     }
+
+
+    public function dataHtmlStyle(): array
+    {
+        return [
+            'external' => [
+                'background: url(https://example.com/_.gif) no-repeat left center;',
+                [
+                    'background' => 'url(https://example.com/_.gif) no-repeat left center',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataHtmlStyle
+     */
+    public function testStyleParser(string $style, array $expected): void
+    {
+        $css = Html::cssStyleToArray($style);
+
+        $this->assertSame($expected, $css);
+    }
 }
 
 namespace Yiisoft\Html;

--- a/tests/common/Tag/Base/TagTest.php
+++ b/tests/common/Tag/Base/TagTest.php
@@ -6,6 +6,7 @@ namespace Yiisoft\Html\Tests\Tag\Base;
 
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Html\Tests\Objects\TestTag;
+use InvalidArgumentException;
 
 final class TagTest extends TestCase
 {
@@ -27,7 +28,7 @@ final class TagTest extends TestCase
             ['<test style="width: 100px; height: 200px;">', ['style' => ['width' => '100px', 'height' => '200px']]],
             ['<test name="position" value="42">', ['value' => 42, 'name' => 'position']],
             [
-                '<test id="x" class="a b" data-a="1" data-b="2" style="width: 100px;" any=\'[1,2]\'>',
+                '<test id="x" class="a b" data-a="1" data-b="2" any=\'[1,2]\' style="width: 100px;">',
                 [
                     'id' => 'x',
                     'class' => ['a', 'b'],
@@ -209,5 +210,54 @@ final class TagTest extends TestCase
         $this->assertNotSame($tag, $tag->id(null));
         $this->assertNotSame($tag, $tag->class('test'));
         $this->assertNotSame($tag, $tag->replaceClass('test'));
+    }
+
+    public function dataAddStyle(): array
+    {
+        return [
+            ['<test style="display: block;">', ['display' => 'block']],
+            ['<test style="display: none;">', ['display' => 'block'], ['display' => 'none']],
+            ['<test style="font-weight: bold; color: red;">', ['font-weight' => 'bold'], ['color' => 'red']],
+        ];
+    }
+
+    public function dataImmutableStyle(): array
+    {
+        return [
+            ['<test class="some" style="color: black;">', ['class' => 'some'], ['color' => 'black']],
+        ];
+    }
+
+    /**
+     * @dataProvider dataAddStyle
+     */
+    public function testAddStyle(string $expected, array $style, ?array $additional = null): void
+    {
+        $tag = TestTag::tag()->addStyle($style);
+
+        if ($additional) {
+            $tag = $tag->addStyle($additional, false);
+        }
+
+        $this->assertSame($expected, (string) $tag);
+    }
+
+    public function testStyleException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        TestTag::tag()->addStyle(new \stdClass());
+    }
+
+    /**
+     * @dataProvider dataImmutableStyle
+     */
+    public function testImmutableStyle(string $expected, array $attributes, array $style): void
+    {
+        $tag = TestTag::tag()
+                ->addStyle($style)
+                ->addAttributes($attributes);
+
+        $this->assertSame($expected, (string) $tag);
     }
 }

--- a/tests/common/Tag/Base/TagTest.php
+++ b/tests/common/Tag/Base/TagTest.php
@@ -28,7 +28,7 @@ final class TagTest extends TestCase
             ['<test style="width: 100px; height: 200px;">', ['style' => ['width' => '100px', 'height' => '200px']]],
             ['<test name="position" value="42">', ['value' => 42, 'name' => 'position']],
             [
-                '<test id="x" class="a b" data-a="1" data-b="2" any=\'[1,2]\' style="width: 100px;">',
+                '<test id="x" class="a b" data-a="1" data-b="2" style="width: 100px;" any=\'[1,2]\'>',
                 [
                     'id' => 'x',
                     'class' => ['a', 'b'],
@@ -221,22 +221,15 @@ final class TagTest extends TestCase
         ];
     }
 
-    public function dataImmutableStyle(): array
-    {
-        return [
-            ['<test class="some" style="color: black;">', ['class' => 'some'], ['color' => 'black']],
-        ];
-    }
-
     /**
      * @dataProvider dataAddStyle
      */
-    public function testAddStyle(string $expected, array $style, ?array $additional = null): void
+    public function testAddStyle(string $expected, array $style, array $additional = []): void
     {
         $tag = TestTag::tag()->addStyle($style);
 
-        if ($additional) {
-            $tag = $tag->addStyle($additional, false);
+        foreach ($additional as $name => $value) {
+            $tag = $tag->styleParam($name, $value);
         }
 
         $this->assertSame($expected, (string) $tag);
@@ -247,17 +240,5 @@ final class TagTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
 
         TestTag::tag()->addStyle(new \stdClass());
-    }
-
-    /**
-     * @dataProvider dataImmutableStyle
-     */
-    public function testImmutableStyle(string $expected, array $attributes, array $style): void
-    {
-        $tag = TestTag::tag()
-                ->addStyle($style)
-                ->addAttributes($attributes);
-
-        $this->assertSame($expected, (string) $tag);
     }
 }

--- a/tests/common/Tag/BodyTest.php
+++ b/tests/common/Tag/BodyTest.php
@@ -24,7 +24,7 @@ final class BodyTest extends TestCase
             (string) Body::tag()
                 ->attributes([
                     'onafterprint' => 'alert(123);',
-                    'style' => 'font-size:20px;',
+                    'style' => 'font-size: 20px;',
                 ])
                 ->content('Welcome Back!')
         );

--- a/tests/common/Tag/BodyTest.php
+++ b/tests/common/Tag/BodyTest.php
@@ -20,7 +20,7 @@ final class BodyTest extends TestCase
     public function testAttributes(): void
     {
         $this->assertSame(
-            '<body onafterprint="alert(123);" style="font-size:20px;">Welcome Back!</body>',
+            '<body onafterprint="alert(123);" style="font-size: 20px;">Welcome Back!</body>',
             (string) Body::tag()
                 ->attributes([
                     'onafterprint' => 'alert(123);',

--- a/tests/common/Tag/ColTest.php
+++ b/tests/common/Tag/ColTest.php
@@ -15,7 +15,7 @@ final class ColTest extends TestCase
             '<col span="2" style="background-color: #f00;">',
             Col::tag()
                 ->span(2)
-                ->attribute('style', 'background-color:#f00;')
+                ->attribute('style', 'background-color: #f00;')
                 ->render()
         );
     }

--- a/tests/common/Tag/ColTest.php
+++ b/tests/common/Tag/ColTest.php
@@ -12,7 +12,7 @@ final class ColTest extends TestCase
     public function testBase(): void
     {
         $this->assertSame(
-            '<col span="2" style="background-color:#f00;">',
+            '<col span="2" style="background-color: #f00;">',
             Col::tag()
                 ->span(2)
                 ->attribute('style', 'background-color:#f00;')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️/❌
| Fixed issues  | #122, #123

1. Mark `Tag::attributes`, `Tag::replaceAttributes`, `Tag::class`, `Tag::replaceClass` as @deprecated
2. Add new methods `Tag::addAttributes`, `Tag::addClass`, `Tag::addStyle`, `Tag::styleParam`
3. Small fix `Html::cssStyleToArray` with external url