### PR TITLE
Add shortcut methods for enctype in `Form`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,82 +2,83 @@
 
 ## 2.4.1 under development
 
-- no changes in this release.
+- New #129: Add methods `enctypeApplicationXWwwFormUrlencoded()`, `enctypeMultipartFormData()` and `enctypeTextPlain()`
+  to `Form` tag class (@vjik) 
 
 ## 2.4.0 May 19, 2022
 
 - New #97: Add classes for tags `Body`, `Article`, `Section`, `Nav`, `Aside`, `Hgroup`, `Header`, `Footer`, `Address`
   and methods `Html::body()`, `Html::article()`, `Html::section()`, `Html::nav()`, `Html::aside()`, `Html::hgroup()`,
-  `Html::header()`, `Html::footer()`, `Html::address()` (soodssr)
-- New #103: Add class for tag `Form` and method `Html::form()` (vjik)
+  `Html::header()`, `Html::footer()`, `Html::address()` (@soodssr)
+- New #103: Add class for tag `Form` and method `Html::form()` (@vjik)
 - New #105: Add specialized class `File` for an input tag with type `file` and methods `Html::file()` and
-  `Input::fileControl()` (vjik)
-- New #109: Add class for tag `Datalist` and method `Html::datalist()` (vjik)
+  `Input::fileControl()` (@vjik)
+- New #109: Add class for tag `Datalist` and method `Html::datalist()` (@vjik)
 - New #109, #117: Add specialized class for input tag with type `Range` and methods `Html::range()`,
- `Input::range()` (vjik)
-- New #111: Add widget `ButtonGroup` (vjik)
-- New #111: Add method `Tag::unionAttributes()` that available for all tags (vjik)
-- New #113: Add class for tag `Legend`, class for tag `Fieldset`, methods `Html::legend()` and `Html::fieldset()` (vjik)
-- Enh #102: Remove psalm type `HtmlAttributes`, too obsessive for package users (vjik)
+ `Input::range()` (@vjik)
+- New #111: Add widget `ButtonGroup` (@vjik)
+- New #111: Add method `Tag::unionAttributes()` that available for all tags (@vjik)
+- New #113: Add class for tag `Legend`, class for tag `Fieldset`, methods `Html::legend()` and `Html::fieldset()` (@vjik)
+- Enh #102: Remove psalm type `HtmlAttributes`, too obsessive for package users (@vjik)
 - Enh #104: Add parameter `$attributes` to methods `Html::input()`, `Html::buttonInput()`, `Html::submitInput()` 
-  and `Html::resetInput()` (vjik)
-- Enh #106: Add option groups support to method `Select::optionsData()` (vjik)
-- Enh #108: Add individual attributes of options and option groups support to method `Select::optionsData()` (vjik)
-- Enh #115: Add methods `CheckboxList::name()` and `RadioList::name()` (vjik)
+  and `Html::resetInput()` (@vjik)
+- Enh #106: Add option groups support to method `Select::optionsData()` (@vjik)
+- Enh #108: Add individual attributes of options and option groups support to method `Select::optionsData()` (@vjik)
+- Enh #115: Add methods `CheckboxList::name()` and `RadioList::name()` (@vjik)
 
 ## 2.3.0 March 25, 2022
 
-- New #95: Add class for tag `Title` and method `Html::title()` (vjik)
+- New #95: Add class for tag `Title` and method `Html::title()` (@vjik)
 - New #96: Add classes for heading tags `H1-6` and methods `Html::h1()`, `Html::h2()`, `Html::h3()`, `Html::h4()`,
-  `Html::h5()`, `Html::h6()` (vjik)
-- New #100: Add classes for tags `Picture`, `Audio`, `Video`, `Source` and `Track` (Gerych1984, vjik)
+  `Html::h5()`, `Html::h6()` (@vjik)
+- New #100: Add classes for tags `Picture`, `Audio`, `Video`, `Source` and `Track` (@Gerych1984, @vjik)
 
 ## 2.2.1 October 24, 2021
 
-- Enh #93: Add support for `yiisoft/arrays` version `^2.0` (vjik)
+- Enh #93: Add support for `yiisoft/arrays` version `^2.0` (@vjik)
 
 ## 2.2.0 October 20, 2021
 
-- New #89: Add method `nofollow()` to the `A` tag (soodssr)
+- New #89: Add method `nofollow()` to the `A` tag (@soodssr)
 - New #90: Add method `itemsFromValues()` to widgets `RadioList` and `CheckboxList` that set items with labels equal
-  to values (vjik)
+  to values (@vjik)
 - New #92: A third optional argument `$attributes` containing tag attributes in terms of name-value pairs has been
   added to methods `Html::textInput()`, `Html::hiddenInput()`, `Html::passwordInput()`, `Html::fileInput()`,
-  `Html::radio()`, `Html::checkbox()`, `Html::textarea()` (vjik)
+  `Html::radio()`, `Html::checkbox()`, `Html::textarea()` (@vjik)
 
 ## 2.1.0 September 23, 2021
 
 - New #88: Add `Noscript` tag support and shortcuts for `Script` tag via methods `Script::noscript()`
-  and `Script::noscriptTag()` (vjik)
+  and `Script::noscriptTag()` (@vjik)
 
 ## 2.0.0 August 24, 2021
 
-- New #74: Add classes for tags `Em`, `Strong`, `B` and `I` (vjik)
-- New #75: Add methods `as()` and `preload()` to the `Link` tag (vjik)
-- New #76: Add `NoEncode` class designed to wrap content that should not be encoded in HTML tags (vjik)
+- New #74: Add classes for tags `Em`, `Strong`, `B` and `I` (@vjik)
+- New #75: Add methods `as()` and `preload()` to the `Link` tag (@vjik)
+- New #76: Add `NoEncode` class designed to wrap content that should not be encoded in HTML tags (@vjik)
 - New #78: Allow pass `null` argument to methods `Tag::class()`, `Tag::replaceClass()`, `BooleanInputTag::label()` and
-  `BooleanInputTag::sideLabel()` (vjik)
+  `BooleanInputTag::sideLabel()` (@vjik)
 - New #82: Add support individual attributes for inputs in `CheckboxList` and `RadioList` widgets via methods
   `CheckboxList::individualInputAttributes()`, `CheckboxList::replaceIndividualInputAttributes()`,
-  `RadioList::individualInputAttributes()` and `RadioList::replaceIndividualInputAttributes()` (vjik)
-- Chg #79: Do not add empty attribute value for empty strings (vjik)
-- Bug #83: Fix `Html::ATTRIBUTE_ORDER` values (terabytesoftw)
+  `RadioList::individualInputAttributes()` and `RadioList::replaceIndividualInputAttributes()` (@vjik)
+- Chg #79: Do not add empty attribute value for empty strings (@vjik)
+- Bug #83: Fix `Html::ATTRIBUTE_ORDER` values (@terabytesoftw)
 
 ## 1.2.0 May 04, 2021
 
 - New #70: Add support `\Stringable` as content in methods `Html::tag()`, `Html::normalTag()`, `Html::a()`,
   `Html::label()`, `Html::option()`, `Html::div()`, `Html::span()`, `Html::p()`, `Html::li()`, `Html::caption()`,
-  `Html::td()`, `Html::th()` (vjik)
-- New #71: Add methods `Script::getContent()` and `Style::getContent()` (vjik)
+  `Html::td()`, `Html::th()` (@vjik)
+- New #71: Add methods `Script::getContent()` and `Style::getContent()` (@vjik)
 
 ## 1.1.0 April 09, 2021
 
-- New #65: Add classes for table tags `Table`, `Caption`, `Colgroup`, `Col`, `Thead`, `Tbody`, `Tfoot`, `Tr`, `Th`, `Td` (vjik)
-- New #69: Add class for tag `Br` (vjik)
+- New #65: Add classes for table tags `Table`, `Caption`, `Colgroup`, `Col`, `Thead`, `Tbody`, `Tfoot`, `Tr`, `Th`, `Td` (@vjik)
+- New #69: Add class for tag `Br` (@vjik)
 
 ## 1.0.1 April 04, 2021
 
-- Bug #68: Fix `TagContentTrait::content()` and `TagContentTrait::addContent()` when used with named parameters (vjik)
+- Bug #68: Fix `TagContentTrait::content()` and `TagContentTrait::addContent()` when used with named parameters (@vjik)
 
 ## 1.0.0 March 17, 2021
 

--- a/src/Tag/Form.php
+++ b/src/Tag/Form.php
@@ -112,7 +112,7 @@ final class Form extends NormalTag
     }
 
     /**
-     * The type that allows file <input> element(s) to upload file data.
+     * The type that allows file `<input>` element(s) to upload file data.
      *
      * @link https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-submission-algorithm:attr-fs-enctype-formdata
      */

--- a/src/Tag/Form.php
+++ b/src/Tag/Form.php
@@ -102,7 +102,7 @@ final class Form extends NormalTag
     }
 
     /**
-     * All characters are encoded before sent.
+     * All characters are encoded before sending.
      *
      * @link https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-submission-algorithm:attr-fs-enctype-urlencoded
      */

--- a/src/Tag/Form.php
+++ b/src/Tag/Form.php
@@ -101,16 +101,31 @@ final class Form extends NormalTag
         return $new;
     }
 
+    /**
+     * All characters are encoded before sent.
+     *
+     * @link https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-submission-algorithm:attr-fs-enctype-urlencoded
+     */
     public function enctypeApplicationXWwwFormUrlencoded(): self
     {
         return $this->enctype(self::ENCTYPE_APPLICATION_X_WWW_FORM_URLENCODED);
     }
 
+    /**
+     * The type that allows file <input> element(s) to upload file data.
+     *
+     * @link https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-submission-algorithm:attr-fs-enctype-formdata
+     */
     public function enctypeMultipartFormData(): self
     {
         return $this->enctype(self::ENCTYPE_MULTIPART_FORM_DATA);
     }
 
+    /**
+     * Sends data without any encoding at all. Not recommended.
+     *
+     * @link https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-submission-algorithm:attr-fs-enctype-text
+     */
     public function enctypeTextPlain(): self
     {
         return $this->enctype(self::ENCTYPE_TEXT_PLAIN);

--- a/src/Tag/Form.php
+++ b/src/Tag/Form.php
@@ -15,6 +15,10 @@ final class Form extends NormalTag
 {
     use TagContentTrait;
 
+    public const ENCTYPE_APPLICATION_X_WWW_FORM_URLENCODED = 'application/x-www-form-urlencoded';
+    public const ENCTYPE_MULTIPART_FORM_DATA = 'multipart/form-data';
+    public const ENCTYPE_TEXT_PLAIN = 'text/plain';
+
     private ?string $csrfToken = null;
     private ?string $csrfName = null;
 
@@ -95,6 +99,21 @@ final class Form extends NormalTag
         $new = clone $this;
         $new->attributes['enctype'] = $enctype;
         return $new;
+    }
+
+    public function enctypeApplicationXWwwFormUrlencoded(): self
+    {
+        return $this->enctype(self::ENCTYPE_APPLICATION_X_WWW_FORM_URLENCODED);
+    }
+
+    public function enctypeMultipartFormData(): self
+    {
+        return $this->enctype(self::ENCTYPE_MULTIPART_FORM_DATA);
+    }
+
+    public function enctypeTextPlain(): self
+    {
+        return $this->enctype(self::ENCTYPE_TEXT_PLAIN);
     }
 
     /**

--- a/tests/common/Tag/FormTest.php
+++ b/tests/common/Tag/FormTest.php
@@ -205,6 +205,36 @@ final class FormTest extends TestCase
         );
     }
 
+    public function testEnctypeApplicationXWwwFormUrlencoded(): void
+    {
+        $this->assertSame(
+            '<form enctype="application/x-www-form-urlencoded"></form>',
+            Form::tag()
+                ->enctypeApplicationXWwwFormUrlencoded()
+                ->render()
+        );
+    }
+
+    public function testEnctypeMultipartFormData(): void
+    {
+        $this->assertSame(
+            '<form enctype="multipart/form-data"></form>',
+            Form::tag()
+                ->enctypeMultipartFormData()
+                ->render()
+        );
+    }
+
+    public function testEnctypeTextPlain(): void
+    {
+        $this->assertSame(
+            '<form enctype="text/plain"></form>',
+            Form::tag()
+                ->enctypeTextPlain()
+                ->render()
+        );
+    }
+
     public function dataMethod(): array
     {
         return [
@@ -288,6 +318,9 @@ final class FormTest extends TestCase
         $this->assertNotSame($tag, $tag->action(null));
         $this->assertNotSame($tag, $tag->autocomplete());
         $this->assertNotSame($tag, $tag->enctype(null));
+        $this->assertNotSame($tag, $tag->enctypeApplicationXWwwFormUrlencoded());
+        $this->assertNotSame($tag, $tag->enctypeMultipartFormData());
+        $this->assertNotSame($tag, $tag->enctypeTextPlain());
         $this->assertNotSame($tag, $tag->method(null));
         $this->assertNotSame($tag, $tag->noValidate());
         $this->assertNotSame($tag, $tag->target(null));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -