### PR TITLE
Add `addAttributes()` and deprecate `attributes()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 2.4.1 under development
 
-- New #122: Add `Tag::addAttributes()`, `ButtonGroup::addButtonAttributes()` and deprecate `Tag::attributes()`,
-  `ButtonGroup::buttonAttributes()` (@vjik)
+- New #122: Add `Tag::addAttributes()`, `ButtonGroup::addButtonAttributes()`, `RadioList::addRadioAttributes()` and 
+  deprecate `Tag::attributes()`, `ButtonGroup::buttonAttributes()`, `RadioList::radioAttributes()` (@vjik)
 
 ## 2.4.0 May 19, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 2.4.1 under development
 
-- New #122: Add `Tag::addAttributes()` and deprecate `Tag::attributes()` (@vjik)
+- New #122: Add `Tag::addAttributes()`, `ButtonGroup::addButtonAttributes()` and deprecate `Tag::attributes()`,
+  `ButtonGroup::buttonAttributes()` (@vjik)
 
 ## 2.4.0 May 19, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## 2.4.1 under development
 
 - New #122: Add `Tag::addAttributes()`, `ButtonGroup::addButtonAttributes()`, `RadioList::addRadioAttributes()`,
- `RadioList::addIndividualInputAttributes()` and deprecate `Tag::attributes()`, `ButtonGroup::buttonAttributes()`, 
- `RadioList::radioAttributes()`, `RadioList::individualInputAttributes()` (@vjik)
+ `RadioList::addIndividualInputAttributes()`, `CheckboxList::addCheckboxAttributes()` and deprecate `Tag::attributes()`,
+ `ButtonGroup::buttonAttributes()`, `RadioList::radioAttributes()`, `RadioList::individualInputAttributes()`,
+ `CheckboxList::checkboxAttributes()` (@vjik)
 
 ## 2.4.0 May 19, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## 2.4.1 under development
 
-- New #122: Add `Tag::addAttributes()`, `ButtonGroup::addButtonAttributes()`, `RadioList::addRadioAttributes()` and 
-  deprecate `Tag::attributes()`, `ButtonGroup::buttonAttributes()`, `RadioList::radioAttributes()` (@vjik)
+- New #122: Add `Tag::addAttributes()`, `ButtonGroup::addButtonAttributes()`, `RadioList::addRadioAttributes()`,
+ `RadioList::addIndividualInputAttributes()` and deprecate `Tag::attributes()`, `ButtonGroup::buttonAttributes()`, 
+ `RadioList::radioAttributes()`, `RadioList::individualInputAttributes()` (@vjik)
 
 ## 2.4.0 May 19, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 - New #122: Add `Tag::addAttributes()`, `ButtonGroup::addButtonAttributes()`, `RadioList::addRadioAttributes()`,
  `RadioList::addIndividualInputAttributes()`, `CheckboxList::addCheckboxAttributes()`,
- `CheckboxList::addIndividualInputAttributes()` and deprecate `Tag::attributes()`, `ButtonGroup::buttonAttributes()`, 
- `RadioList::radioAttributes()`, `RadioList::individualInputAttributes()`, `CheckboxList::checkboxAttributes()`, 
- `CheckboxList::individualInputAttributes()` (@vjik)
+ `CheckboxList::addIndividualInputAttributes()`, `File::addUncheckInputAttributes()` and deprecate `Tag::attributes()`,
+ `ButtonGroup::buttonAttributes()`, `RadioList::radioAttributes()`, `RadioList::individualInputAttributes()`, 
+ `CheckboxList::checkboxAttributes()`, `CheckboxList::individualInputAttributes()`, `File::uncheckInputAttributes()`
+ (@vjik)
 
 ## 2.4.0 May 19, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.4.1 under development
 
-- no changes in this release.
+- New #122: Add `Tag::addAttributes()` and deprecate `Tag::attributes()` (@vjik)
 
 ## 2.4.0 May 19, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 - New #122: Add `Tag::addAttributes()`, `ButtonGroup::addButtonAttributes()`, `RadioList::addRadioAttributes()`,
  `RadioList::addIndividualInputAttributes()`, `CheckboxList::addCheckboxAttributes()`,
- `CheckboxList::addIndividualInputAttributes()`, `File::addUncheckInputAttributes()` and deprecate `Tag::attributes()`,
- `ButtonGroup::buttonAttributes()`, `RadioList::radioAttributes()`, `RadioList::individualInputAttributes()`, 
- `CheckboxList::checkboxAttributes()`, `CheckboxList::individualInputAttributes()`, `File::uncheckInputAttributes()`
- (@vjik)
+ `CheckboxList::addIndividualInputAttributes()`, `File::addUncheckInputAttributes()`, `Range::addOutputAttributes()` and 
+ deprecate `Tag::attributes()`, `ButtonGroup::buttonAttributes()`, `RadioList::radioAttributes()`,
+ `RadioList::individualInputAttributes()`, `CheckboxList::checkboxAttributes()`,
+ `CheckboxList::individualInputAttributes()`, `File::uncheckInputAttributes()`, `Range::outputAttributes()` (@vjik)
 
 ## 2.4.0 May 19, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 ## 2.4.1 under development
 
 - New #122: Add `Tag::addAttributes()`, `ButtonGroup::addButtonAttributes()`, `RadioList::addRadioAttributes()`,
- `RadioList::addIndividualInputAttributes()`, `CheckboxList::addCheckboxAttributes()` and deprecate `Tag::attributes()`,
- `ButtonGroup::buttonAttributes()`, `RadioList::radioAttributes()`, `RadioList::individualInputAttributes()`,
- `CheckboxList::checkboxAttributes()` (@vjik)
+ `RadioList::addIndividualInputAttributes()`, `CheckboxList::addCheckboxAttributes()`,
+ `CheckboxList::addIndividualInputAttributes()` and deprecate `Tag::attributes()`, `ButtonGroup::buttonAttributes()`, 
+ `RadioList::radioAttributes()`, `RadioList::individualInputAttributes()`, `CheckboxList::checkboxAttributes()`, 
+ `CheckboxList::individualInputAttributes()` (@vjik)
 
 ## 2.4.0 May 19, 2022
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ echo \Yiisoft\Html\Widget\ButtonGroup::create()
 	    \Yiisoft\Html\Html::resetButton('Send'),
 	)
 	->containerAttributes(['class' => 'actions'])
-	->buttonAttributes(['form' => 'CreatePost']);
+	->replaceButtonAttributes(['form' => 'CreatePost']);
 ```
 
 Result will be:

--- a/src/Html.php
+++ b/src/Html.php
@@ -419,7 +419,7 @@ final class Html
     {
         $tag = Title::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->replaceAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -433,7 +433,7 @@ final class Html
     {
         $tag = Meta::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->replaceAttributes($attributes);
         }
         return $tag;
     }
@@ -447,11 +447,11 @@ final class Html
     public static function link(?string $url = null, array $attributes = []): Link
     {
         $tag = Link::tag();
+        if (!empty($attributes)) {
+            $tag = $tag->replaceAttributes($attributes);
+        }
         if ($url !== null) {
             $tag = $tag->url($url);
-        }
-        if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
         }
         return $tag;
     }
@@ -466,7 +466,7 @@ final class Html
     {
         $tag = Link::toCssFile($url);
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $tag;
     }
@@ -481,7 +481,7 @@ final class Html
     {
         $tag = Script::tag()->url($url);
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $tag;
     }
@@ -497,14 +497,14 @@ final class Html
     public static function a($content = '', ?string $url = null, array $attributes = []): A
     {
         $tag = A::tag();
+        if (!empty($attributes)) {
+            $tag = $tag->replaceAttributes($attributes);
+        }
         if ($content !== '') {
             $tag = $tag->content($content);
         }
         if ($url !== null) {
             $tag = $tag->url($url);
-        }
-        if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
         }
         return $tag;
     }
@@ -522,7 +522,7 @@ final class Html
             ->content($content)
             ->mailto($mail ?? $content);
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $tag;
     }
@@ -554,7 +554,7 @@ final class Html
     {
         $tag = Fieldset::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->replaceAttributes($attributes);
         }
         return $tag;
     }
@@ -576,7 +576,7 @@ final class Html
             $attributes['method'] = $method;
         }
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->replaceAttributes($attributes);
         }
         return $tag;
     }
@@ -613,7 +613,7 @@ final class Html
             $tag = $tag->content($content);
         }
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->replaceAttributes($attributes);
         }
         return $tag;
     }
@@ -630,7 +630,7 @@ final class Html
     {
         $tag = Button::button($content);
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $tag;
     }
@@ -647,7 +647,7 @@ final class Html
     {
         $tag = Button::submit($content);
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $tag;
     }
@@ -664,7 +664,7 @@ final class Html
     {
         $tag = Button::reset($content);
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $tag;
     }
@@ -688,7 +688,7 @@ final class Html
             $tag = $tag->value($value);
         }
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $tag;
     }
@@ -705,7 +705,7 @@ final class Html
     {
         $tag = Input::button($label);
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $tag;
     }
@@ -722,7 +722,7 @@ final class Html
     {
         $tag = Input::submitButton($label);
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $tag;
     }
@@ -739,7 +739,7 @@ final class Html
     {
         $tag = Input::resetButton($label);
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->addAttributes($attributes);
         }
         return $tag;
     }
@@ -754,7 +754,7 @@ final class Html
     public static function textInput(?string $name = null, $value = null, array $attributes = []): Input
     {
         $tag = Input::text($name, $value);
-        return $attributes === [] ? $tag : $tag->attributes($attributes);
+        return $attributes === [] ? $tag : $tag->addAttributes($attributes);
     }
 
     /**
@@ -769,7 +769,7 @@ final class Html
     public static function hiddenInput(?string $name = null, $value = null, array $attributes = []): Input
     {
         $tag = Input::hidden($name, $value);
-        return $attributes === [] ? $tag : $tag->attributes($attributes);
+        return $attributes === [] ? $tag : $tag->addAttributes($attributes);
     }
 
     /**
@@ -784,7 +784,7 @@ final class Html
     public static function passwordInput(?string $name = null, $value = null, array $attributes = []): Input
     {
         $tag = Input::password($name, $value);
-        return $attributes === [] ? $tag : $tag->attributes($attributes);
+        return $attributes === [] ? $tag : $tag->addAttributes($attributes);
     }
 
     /**
@@ -805,7 +805,7 @@ final class Html
     public static function fileInput(?string $name = null, $value = null, array $attributes = []): Input
     {
         $tag = Input::file($name, $value);
-        return $attributes === [] ? $tag : $tag->attributes($attributes);
+        return $attributes === [] ? $tag : $tag->addAttributes($attributes);
     }
 
     /**
@@ -825,7 +825,7 @@ final class Html
     {
         /** @psalm-suppress DeprecatedMethod */
         $tag = Input::fileControl($name, $value);
-        return $attributes === [] ? $tag : $tag->attributes($attributes);
+        return $attributes === [] ? $tag : $tag->addAttributes($attributes);
     }
 
     /**
@@ -840,7 +840,7 @@ final class Html
     public static function radio(?string $name = null, $value = null, array $attributes = []): Radio
     {
         $tag = Input::radio($name, $value);
-        return $attributes === [] ? $tag : $tag->attributes($attributes);
+        return $attributes === [] ? $tag : $tag->addAttributes($attributes);
     }
 
     /**
@@ -855,7 +855,7 @@ final class Html
     public static function range(?string $name = null, $value = null, array $attributes = []): Range
     {
         $tag = Input::range($name, $value);
-        return $attributes === [] ? $tag : $tag->attributes($attributes);
+        return $attributes === [] ? $tag : $tag->addAttributes($attributes);
     }
 
     /**
@@ -870,7 +870,7 @@ final class Html
     public static function checkbox(?string $name = null, $value = null, array $attributes = []): Checkbox
     {
         $tag = Input::checkbox($name, $value);
-        return $attributes === [] ? $tag : $tag->attributes($attributes);
+        return $attributes === [] ? $tag : $tag->addAttributes($attributes);
     }
 
     /**
@@ -889,7 +889,7 @@ final class Html
         if (!empty($value)) {
             $tag = $tag->value($value);
         }
-        return $attributes === [] ? $tag : $tag->attributes($attributes);
+        return $attributes === [] ? $tag : $tag->addAttributes($attributes);
     }
 
     /**
@@ -962,7 +962,7 @@ final class Html
     {
         $tag = Div::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->replaceAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -977,7 +977,7 @@ final class Html
     {
         $tag = Span::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->replaceAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -992,7 +992,7 @@ final class Html
     {
         $tag = Em::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->replaceAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1007,7 +1007,7 @@ final class Html
     {
         $tag = Strong::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->replaceAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1022,7 +1022,7 @@ final class Html
     {
         $tag = B::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->replaceAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1037,7 +1037,7 @@ final class Html
     {
         $tag = I::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->replaceAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1052,7 +1052,7 @@ final class Html
     {
         $tag = H1::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->replaceAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1067,7 +1067,7 @@ final class Html
     {
         $tag = H2::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->replaceAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1082,7 +1082,7 @@ final class Html
     {
         $tag = H3::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->replaceAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1097,7 +1097,7 @@ final class Html
     {
         $tag = H4::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->replaceAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1112,7 +1112,7 @@ final class Html
     {
         $tag = H5::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->replaceAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1127,7 +1127,7 @@ final class Html
     {
         $tag = H6::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->replaceAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1142,7 +1142,7 @@ final class Html
     {
         $tag = P::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->replaceAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1184,7 +1184,7 @@ final class Html
     {
         $tag = Datalist::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->replaceAttributes($attributes);
         }
         return $tag;
     }
@@ -1379,7 +1379,7 @@ final class Html
     {
         $tag = Body::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->replaceAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1394,7 +1394,7 @@ final class Html
     {
         $tag = Article::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->replaceAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1409,7 +1409,7 @@ final class Html
     {
         $tag = Section::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->replaceAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1424,7 +1424,7 @@ final class Html
     {
         $tag = Nav::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->replaceAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1439,7 +1439,7 @@ final class Html
     {
         $tag = Aside::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->replaceAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1454,7 +1454,7 @@ final class Html
     {
         $tag = Hgroup::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->replaceAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1469,7 +1469,7 @@ final class Html
     {
         $tag = Header::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->replaceAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1484,7 +1484,7 @@ final class Html
     {
         $tag = Footer::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->replaceAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1499,7 +1499,7 @@ final class Html
     {
         $tag = Address::tag();
         if (!empty($attributes)) {
-            $tag = $tag->attributes($attributes);
+            $tag = $tag->replaceAttributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }

--- a/src/Tag/Base/ListTag.php
+++ b/src/Tag/Base/ListTag.php
@@ -40,7 +40,7 @@ abstract class ListTag extends NormalTag
         $items = array_map(static function (string $string) use ($attributes, $encode) {
             return Li::tag()
                 ->content($string)
-                ->attributes($attributes)
+                ->replaceAttributes($attributes)
                 ->encode($encode);
         }, $strings);
         return $this->items(...$items);

--- a/src/Tag/Base/Tag.php
+++ b/src/Tag/Base/Tag.php
@@ -22,8 +22,8 @@ abstract class Tag implements NoEncodeStringableInterface
      *
      * @return static
      *
-     * @deprecated Use {@see addAttributes()} or {@see replaceAttributes} instead. Please note that in next major
-     * version method `replaceAttributes()` will be renamed to `attributes()`.
+     * @deprecated Use {@see addAttributes()} or {@see replaceAttributes()} instead. In the next major version
+     * `replaceAttributes()` method will be renamed to `attributes()`.
      */
     final public function attributes(array $attributes): self
     {

--- a/src/Tag/Base/Tag.php
+++ b/src/Tag/Base/Tag.php
@@ -21,8 +21,24 @@ abstract class Tag implements NoEncodeStringableInterface
      * @param array $attributes Name-value set of attributes.
      *
      * @return static
+     *
+     * @deprecated Use {@see addAttributes()} or {@see replaceAttributes} instead. Please note that in next major
+     * version method `replaceAttributes()` will be renamed to `attributes()`.
      */
     final public function attributes(array $attributes): self
+    {
+        return $this->addAttributes($attributes);
+    }
+
+    /**
+     * Add a set of attributes to existing tag attributes.
+     * Same named attributes are replaced.
+     *
+     * @param array $attributes Name-value set of attributes.
+     *
+     * @return static
+     */
+    final public function addAttributes(array $attributes): self
     {
         $new = clone $this;
         $new->attributes = array_merge($new->attributes, $attributes);
@@ -98,7 +114,7 @@ abstract class Tag implements NoEncodeStringableInterface
         $new = clone $this;
         Html::addCssClass(
             $new->attributes,
-            array_filter($class, static fn ($c) => $c !== null),
+            array_filter($class, static fn($c) => $c !== null),
         );
         return $new;
     }
@@ -113,7 +129,7 @@ abstract class Tag implements NoEncodeStringableInterface
     final public function replaceClass(?string ...$class): self
     {
         $new = clone $this;
-        $new->attributes['class'] = array_filter($class, static fn ($c) => $c !== null);
+        $new->attributes['class'] = array_filter($class, static fn($c) => $c !== null);
         return $new;
     }
 

--- a/src/Tag/Input/File.php
+++ b/src/Tag/Input/File.php
@@ -26,7 +26,16 @@ final class File extends InputTag
         return $new;
     }
 
+    /**
+     * @deprecated Use {@see addUncheckInputAttributes()} or {@see replaceUncheckInputAttributes()} instead. In the next
+     * major version `replaceUncheckInputAttributes()` method will be renamed to `uncheckInputAttributes()`.
+     */
     public function uncheckInputAttributes(array $attributes): self
+    {
+        return $this->addUncheckInputAttributes($attributes);
+    }
+
+    public function addUncheckInputAttributes(array $attributes): self
     {
         $new = clone $this;
         $new->uncheckInputAttributes = array_merge($new->uncheckInputAttributes, $attributes);

--- a/src/Tag/Input/Range.php
+++ b/src/Tag/Input/Range.php
@@ -128,7 +128,7 @@ final class Range extends InputTag
         }
 
         return "\n" . CustomTag::name($this->outputTag)
-                ->attributes($this->outputAttributes)
+                ->replaceAttributes($this->outputAttributes)
                 ->content((string) ($this->attributes['value'] ?? '-'))
                 ->id($this->outputId)
                 ->render();

--- a/src/Tag/Input/Range.php
+++ b/src/Tag/Input/Range.php
@@ -97,7 +97,16 @@ final class Range extends InputTag
         return $new;
     }
 
+    /**
+     * @deprecated Use {@see addOutputAttributes()} or {@see replaceOutputAttributes()} instead. In the next major
+     * version `replaceOutputAttributes()` method will be renamed to `outputAttributes()`.
+     */
     public function outputAttributes(array $attributes): self
+    {
+        return $this->addOutputAttributes($attributes);
+    }
+
+    public function addOutputAttributes(array $attributes): self
     {
         $new = clone $this;
         $new->outputAttributes = array_merge($this->outputAttributes, $attributes);

--- a/src/Tag/Optgroup.php
+++ b/src/Tag/Optgroup.php
@@ -37,7 +37,7 @@ final class Optgroup extends NormalTag
         $options = [];
         foreach ($data as $value => $content) {
             $options[] = Option::tag()
-                ->attributes($optionsAttributes[$value] ?? [])
+                ->replaceAttributes($optionsAttributes[$value] ?? [])
                 ->value($value)
                 ->content($content)
                 ->encode($encode);

--- a/src/Tag/Select.php
+++ b/src/Tag/Select.php
@@ -151,11 +151,11 @@ final class Select extends NormalTag
             if (is_array($content)) {
                 $items[] = Optgroup::tag()
                     ->label((string) $value)
-                    ->attributes($groupsAttributes[$value] ?? [])
+                    ->addAttributes($groupsAttributes[$value] ?? [])
                     ->optionsData($content, $encode, $optionsAttributes);
             } else {
                 $items[] = Option::tag()
-                    ->attributes($optionsAttributes[$value] ?? [])
+                    ->replaceAttributes($optionsAttributes[$value] ?? [])
                     ->value($value)
                     ->content($content)
                     ->encode($encode);

--- a/src/Tag/Tr.php
+++ b/src/Tag/Tr.php
@@ -67,7 +67,7 @@ final class Tr extends NormalTag
         return array_map(static function (string $string) use ($attributes, $encode) {
             return Td::tag()
                 ->content($string)
-                ->attributes($attributes)
+                ->replaceAttributes($attributes)
                 ->encode($encode);
         }, $strings);
     }
@@ -102,7 +102,7 @@ final class Tr extends NormalTag
         return array_map(static function (string $string) use ($attributes, $encode) {
             return Th::tag()
                 ->content($string)
-                ->attributes($attributes)
+                ->replaceAttributes($attributes)
                 ->encode($encode);
         }, $strings);
     }

--- a/src/Widget/ButtonGroup.php
+++ b/src/Widget/ButtonGroup.php
@@ -88,7 +88,16 @@ final class ButtonGroup implements NoEncodeStringableInterface
         return $this->buttons(...$buttons);
     }
 
+    /**
+     * @deprecated Use {@see addButtonAttributes()} or {@see replaceButtonAttributes} instead. Please note that in
+     * next major version method `replaceButtonAttributes()` will be renamed to `buttonAttributes()`.
+     */
     public function buttonAttributes(array $attributes): self
+    {
+        return $this->addButtonAttributes($attributes);
+    }
+
+    public function addButtonAttributes(array $attributes): self
     {
         $new = clone $this;
         $new->buttonAttributes = array_merge($new->buttonAttributes, $attributes);

--- a/src/Widget/ButtonGroup.php
+++ b/src/Widget/ButtonGroup.php
@@ -89,8 +89,8 @@ final class ButtonGroup implements NoEncodeStringableInterface
     }
 
     /**
-     * @deprecated Use {@see addButtonAttributes()} or {@see replaceButtonAttributes} instead. Please note that in
-     * next major version method `replaceButtonAttributes()` will be renamed to `buttonAttributes()`.
+     * @deprecated Use {@see addButtonAttributes()} or {@see replaceButtonAttributes()} instead. In the next major
+     * version `replaceButtonAttributes()` method will be renamed to `buttonAttributes()`.
      */
     public function buttonAttributes(array $attributes): self
     {

--- a/src/Widget/CheckboxList/CheckboxList.php
+++ b/src/Widget/CheckboxList/CheckboxList.php
@@ -111,8 +111,20 @@ final class CheckboxList implements NoEncodeStringableInterface
 
     /**
      * @param array[] $attributes
+     *
+     * @deprecated Use {@see addIndividualInputAttributes()} or {@see replaceIndividualInputAttributes()} instead. In
+     * the next major version `replaceIndividualInputAttributes()` method will be renamed to
+     * `individualInputAttributes()`.
      */
     public function individualInputAttributes(array $attributes): self
+    {
+        return $this->addIndividualInputAttributes($attributes);
+    }
+
+    /**
+     * @param array[] $attributes
+     */
+    public function addIndividualInputAttributes(array $attributes): self
     {
         $new = clone $this;
         $new->individualInputAttributes = array_replace($new->individualInputAttributes, $attributes);

--- a/src/Widget/CheckboxList/CheckboxList.php
+++ b/src/Widget/CheckboxList/CheckboxList.php
@@ -283,7 +283,7 @@ final class CheckboxList implements NoEncodeStringableInterface
                 Html::getNonArrayableName($this->name),
                 $this->uncheckValue
             )
-                ->attributes(
+                ->addAttributes(
                     array_merge(
                         [
                             // Make sure disabled input is not sending any value
@@ -302,8 +302,7 @@ final class CheckboxList implements NoEncodeStringableInterface
             return ($this->itemFormatter)($item);
         }
 
-        $checkbox = Html::checkbox($item->name, $item->value)
-            ->attributes($item->checkboxAttributes)
+        $checkbox = Html::checkbox($item->name, $item->value, $item->checkboxAttributes)
             ->checked($item->checked)
             ->label($item->label)
             ->labelEncode($item->encodeLabel);

--- a/src/Widget/CheckboxList/CheckboxList.php
+++ b/src/Widget/CheckboxList/CheckboxList.php
@@ -86,7 +86,16 @@ final class CheckboxList implements NoEncodeStringableInterface
         return $new;
     }
 
+    /**
+     * @deprecated Use {@see addCheckboxAttributes()} or {@see replaceCheckboxAttributes()} instead. In the next major
+     * version `replaceCheckboxAttributes()` method will be renamed to `checkboxAttributes()`.
+     */
     public function checkboxAttributes(array $attributes): self
+    {
+        return $this->addCheckboxAttributes($attributes);
+    }
+
+    public function addCheckboxAttributes(array $attributes): self
     {
         $new = clone $this;
         $new->checkboxAttributes = array_merge($new->checkboxAttributes, $attributes);

--- a/src/Widget/RadioList/RadioList.php
+++ b/src/Widget/RadioList/RadioList.php
@@ -256,7 +256,7 @@ final class RadioList implements NoEncodeStringableInterface
                 Html::getNonArrayableName($this->name),
                 $this->uncheckValue
             )
-                ->attributes(
+                ->addAttributes(
                     array_merge(
                         [
                             // Make sure disabled input is not sending any value
@@ -275,8 +275,7 @@ final class RadioList implements NoEncodeStringableInterface
             return ($this->itemFormatter)($item);
         }
 
-        $radio = Html::radio($item->name, $item->value)
-            ->attributes($item->radioAttributes)
+        $radio = Html::radio($item->name, $item->value, $item->radioAttributes)
             ->checked($item->checked)
             ->label($item->label)
             ->labelEncode($item->encodeLabel);

--- a/src/Widget/RadioList/RadioList.php
+++ b/src/Widget/RadioList/RadioList.php
@@ -79,7 +79,16 @@ final class RadioList implements NoEncodeStringableInterface
         return $new;
     }
 
+    /**
+     * @deprecated Use {@see addRadioAttributes()} or {@see replaceRadioAttributes} instead. Please note that in
+     * next major version method `replaceRadioAttributes()` will be renamed to `radioAttributes()`.
+     */
     public function radioAttributes(array $attributes): self
+    {
+        return $this->addRadioAttributes($attributes);
+    }
+
+    public function addRadioAttributes(array $attributes): self
     {
         $new = clone $this;
         $new->radioAttributes = array_merge($new->radioAttributes, $attributes);

--- a/src/Widget/RadioList/RadioList.php
+++ b/src/Widget/RadioList/RadioList.php
@@ -80,8 +80,8 @@ final class RadioList implements NoEncodeStringableInterface
     }
 
     /**
-     * @deprecated Use {@see addRadioAttributes()} or {@see replaceRadioAttributes} instead. Please note that in
-     * next major version method `replaceRadioAttributes()` will be renamed to `radioAttributes()`.
+     * @deprecated Use {@see addRadioAttributes()} or {@see replaceRadioAttributes()} instead. In the next major version
+     * `replaceRadioAttributes()` method will be renamed to `radioAttributes()`.
      */
     public function radioAttributes(array $attributes): self
     {
@@ -105,8 +105,8 @@ final class RadioList implements NoEncodeStringableInterface
     /**
      * @param array[] $attributes
      *
-     * @deprecated Use {@see addIndividualInputAttributes()} or {@see replaceIndividualInputAttributes} instead. Please
-     * note that in next major version method `replaceIndividualInputAttributes()` will be renamed to
+     * @deprecated Use {@see addIndividualInputAttributes()} or {@see replaceIndividualInputAttributes()} instead. In
+     * the next major version `replaceIndividualInputAttributes()` method will be renamed to
      * `individualInputAttributes()`.
      */
     public function individualInputAttributes(array $attributes): self

--- a/src/Widget/RadioList/RadioList.php
+++ b/src/Widget/RadioList/RadioList.php
@@ -104,8 +104,20 @@ final class RadioList implements NoEncodeStringableInterface
 
     /**
      * @param array[] $attributes
+     *
+     * @deprecated Use {@see addIndividualInputAttributes()} or {@see replaceIndividualInputAttributes} instead. Please
+     * note that in next major version method `replaceIndividualInputAttributes()` will be renamed to
+     * `individualInputAttributes()`.
      */
     public function individualInputAttributes(array $attributes): self
+    {
+        return $this->addIndividualInputAttributes($attributes);
+    }
+
+    /**
+     * @param array[] $attributes
+     */
+    public function addIndividualInputAttributes(array $attributes): self
     {
         $new = clone $this;
         $new->individualInputAttributes = array_replace($new->individualInputAttributes, $attributes);

--- a/tests/common/Tag/ArticleTest.php
+++ b/tests/common/Tag/ArticleTest.php
@@ -22,7 +22,8 @@ final class ArticleTest extends TestCase
                     Header::tag()->content(H1::tag()->content('Heading 1'))
                     . P::tag()->content('Article content')
                     . Footer::tag()->content('Footer')
-                )->encode(false)
+                )
+                ->encode(false)
         );
     }
 }

--- a/tests/common/Tag/Base/TagTest.php
+++ b/tests/common/Tag/Base/TagTest.php
@@ -61,7 +61,7 @@ final class TagTest extends TestCase
      */
     public function testAttributes(string $expected, array $attributes): void
     {
-        $this->assertSame($expected, (string)TestTag::tag()->attributes($attributes));
+        $this->assertSame($expected, (string)TestTag::tag()->addAttributes($attributes));
         $this->assertSame($expected, (string)TestTag::tag()->replaceAttributes($attributes));
     }
 
@@ -72,7 +72,7 @@ final class TagTest extends TestCase
             TestTag::tag()
                 ->id('color')
                 ->class('red')
-                ->attributes(['class' => 'green'])
+                ->addAttributes(['class' => 'green'])
                 ->render(),
         );
     }
@@ -203,6 +203,7 @@ final class TagTest extends TestCase
     {
         $tag = TestTag::tag();
         $this->assertNotSame($tag, $tag->attributes([]));
+        $this->assertNotSame($tag, $tag->addAttributes([]));
         $this->assertNotSame($tag, $tag->replaceAttributes([]));
         $this->assertNotSame($tag, $tag->unionAttributes([]));
         $this->assertNotSame($tag, $tag->attribute('id', null));

--- a/tests/common/Tag/BodyTest.php
+++ b/tests/common/Tag/BodyTest.php
@@ -22,7 +22,7 @@ final class BodyTest extends TestCase
         $this->assertSame(
             '<body onafterprint="alert(123);" style="font-size:20px;">Welcome Back!</body>',
             (string) Body::tag()
-                ->attributes([
+                ->replaceAttributes([
                     'onafterprint' => 'alert(123);',
                     'style' => 'font-size:20px;',
                 ])

--- a/tests/common/Tag/FieldsetTest.php
+++ b/tests/common/Tag/FieldsetTest.php
@@ -89,7 +89,7 @@ final class FieldsetTest extends TestCase
                 HTML,
                 Legend::tag()
                     ->content('Hello')
-                    ->attributes(['id' => 'MyLegend']),
+                    ->replaceAttributes(['id' => 'MyLegend']),
             ],
         ];
     }

--- a/tests/common/Tag/Input/FileTest.php
+++ b/tests/common/Tag/Input/FileTest.php
@@ -86,8 +86,8 @@ final class FileTest extends TestCase
         $result = File::tag()
             ->name('avatar')
             ->uncheckValue(7)
-            ->uncheckInputAttributes(['id' => 'FileHidden'])
-            ->uncheckInputAttributes(['data-key' => '100'])
+            ->addUncheckInputAttributes(['id' => 'FileHidden'])
+            ->addUncheckInputAttributes(['data-key' => '100'])
             ->form('post')
             ->render();
 
@@ -103,7 +103,7 @@ final class FileTest extends TestCase
         $result = File::tag()
             ->name('avatar')
             ->uncheckValue(7)
-            ->uncheckInputAttributes(['id' => 'FileHidden'])
+            ->addUncheckInputAttributes(['id' => 'FileHidden'])
             ->replaceUncheckInputAttributes(['data-key' => '100'])
             ->form('post')
             ->render();
@@ -188,6 +188,7 @@ final class FileTest extends TestCase
 
         $this->assertNotSame($tag, $tag->uncheckValue(null));
         $this->assertNotSame($tag, $tag->uncheckInputAttributes([]));
+        $this->assertNotSame($tag, $tag->addUncheckInputAttributes([]));
         $this->assertNotSame($tag, $tag->replaceUncheckInputAttributes([]));
         $this->assertNotSame($tag, $tag->accept(null));
         $this->assertNotSame($tag, $tag->multiple());

--- a/tests/common/Tag/Input/RangeTest.php
+++ b/tests/common/Tag/Input/RangeTest.php
@@ -124,12 +124,12 @@ final class RangeTest extends TestCase
         );
     }
 
-    public function testOutputAttributes(): void
+    public function testAddOutputAttributes(): void
     {
         $tag = Range::tag()
             ->showOutput()
-            ->outputAttributes(['class' => 'red'])
-            ->outputAttributes(['id' => 'UID']);
+            ->addOutputAttributes(['class' => 'red'])
+            ->addOutputAttributes(['id' => 'UID']);
 
         $this->assertSame(
             '<input type="range" ' .
@@ -143,7 +143,7 @@ final class RangeTest extends TestCase
     {
         $tag = Range::tag()
             ->showOutput()
-            ->outputAttributes(['class' => 'red'])
+            ->addOutputAttributes(['class' => 'red'])
             ->replaceOutputAttributes(['id' => 'UID']);
 
         $this->assertSame(
@@ -158,7 +158,7 @@ final class RangeTest extends TestCase
     {
         $tag = Range::tag()
             ->showOutput()
-            ->outputAttributes(['id' => 'UID']);
+            ->replaceOutputAttributes(['id' => 'UID']);
 
         $this->assertMatchesRegularExpression(
             '~<input type="range" ' .
@@ -186,7 +186,7 @@ final class RangeTest extends TestCase
     {
         $tag = Range::tag()
             ->showOutput()
-            ->outputAttributes(['class' => 'red']);
+            ->replaceOutputAttributes(['class' => 'red']);
 
         $this->assertMatchesRegularExpression(
             '~<input type="range" ' .
@@ -230,6 +230,7 @@ final class RangeTest extends TestCase
         $this->assertNotSame($tag, $tag->showOutput());
         $this->assertNotSame($tag, $tag->outputTag('b'));
         $this->assertNotSame($tag, $tag->outputAttributes([]));
+        $this->assertNotSame($tag, $tag->addOutputAttributes([]));
         $this->assertNotSame($tag, $tag->replaceOutputAttributes([]));
     }
 }

--- a/tests/common/Widget/ButtonGroupTest.php
+++ b/tests/common/Widget/ButtonGroupTest.php
@@ -170,14 +170,14 @@ final class ButtonGroupTest extends TestCase
         );
     }
 
-    public function testButtonAttributes(): void
+    public function testAddNewButtonAttributes(): void
     {
         $widget = ButtonGroup::create()
             ->buttons(
                 Html::button('Show'),
                 Html::button('Hide'),
             )
-            ->buttonAttributes(['class' => 'base']);
+            ->addButtonAttributes(['class' => 'base']);
 
         $this->assertStringContainsStringIgnoringLineEndings(
             <<<HTML
@@ -197,8 +197,8 @@ final class ButtonGroupTest extends TestCase
                 Html::button('Show'),
                 Html::button('Hide'),
             )
-            ->buttonAttributes(['class' => 'base'])
-            ->buttonAttributes(['data-key' => '42'])
+            ->addButtonAttributes(['class' => 'base'])
+            ->addButtonAttributes(['data-key' => '42'])
             ->disabled();
 
         $this->assertStringContainsStringIgnoringLineEndings(
@@ -219,7 +219,7 @@ final class ButtonGroupTest extends TestCase
                 Html::button('Show')->class('red'),
                 Html::button('Hide'),
             )
-            ->buttonAttributes(['class' => 'base']);
+            ->replaceButtonAttributes(['class' => 'base']);
 
         $this->assertStringContainsStringIgnoringLineEndings(
             <<<HTML
@@ -372,6 +372,7 @@ final class ButtonGroupTest extends TestCase
         $this->assertNotSame($widget, $widget->buttons());
         $this->assertNotSame($widget, $widget->buttonsData([]));
         $this->assertNotSame($widget, $widget->buttonAttributes([]));
+        $this->assertNotSame($widget, $widget->addButtonAttributes([]));
         $this->assertNotSame($widget, $widget->replaceButtonAttributes([]));
         $this->assertNotSame($widget, $widget->disabled());
         $this->assertNotSame($widget, $widget->form(null));

--- a/tests/common/Widget/CheckboxListTest.php
+++ b/tests/common/Widget/CheckboxListTest.php
@@ -114,7 +114,7 @@ final class CheckboxListTest extends TestCase
                     1 => 'One',
                     2 => 'Two',
                 ])
-                ->checkboxAttributes(['class' => 'red'])
+                ->replaceCheckboxAttributes(['class' => 'red'])
                 ->withoutContainer()
                 ->render(),
         );
@@ -131,7 +131,7 @@ final class CheckboxListTest extends TestCase
                     2 => 'Two',
                 ])
                 ->readonly()
-                ->checkboxAttributes(['class' => 'red'])
+                ->addCheckboxAttributes(['class' => 'red'])
                 ->withoutContainer()
                 ->render(),
         );
@@ -166,7 +166,7 @@ final class CheckboxListTest extends TestCase
                     2 => 'Two',
                     3 => 'Three',
                 ])
-                ->checkboxAttributes(['class' => 'red'])
+                ->replaceCheckboxAttributes(['class' => 'red'])
                 ->individualInputAttributes([
                     2 => ['class' => 'blue'],
                     3 => ['class' => 'green'],
@@ -188,7 +188,7 @@ final class CheckboxListTest extends TestCase
                     2 => 'Two',
                 ])
                 ->uncheckValue(0)
-                ->checkboxAttributes(['class' => 'red'])
+                ->replaceCheckboxAttributes(['class' => 'red'])
                 ->individualInputAttributes([
                     0 => ['class' => 'blue'],
                 ])
@@ -209,7 +209,7 @@ final class CheckboxListTest extends TestCase
                     2 => 'Two',
                     3 => 'Three',
                 ])
-                ->checkboxAttributes(['class' => 'red'])
+                ->replaceCheckboxAttributes(['class' => 'red'])
                 ->individualInputAttributes([
                     2 => ['class' => 'blue'],
                     3 => ['class' => 'green'],
@@ -235,7 +235,7 @@ final class CheckboxListTest extends TestCase
                     2 => 'Two',
                     3 => 'Three',
                 ])
-                ->checkboxAttributes(['class' => 'red'])
+                ->replaceCheckboxAttributes(['class' => 'red'])
                 ->individualInputAttributes([
                     2 => ['class' => 'blue'],
                     3 => ['class' => 'green'],
@@ -694,6 +694,7 @@ final class CheckboxListTest extends TestCase
         $this->assertNotSame($widget, $widget->containerTag(''));
         $this->assertNotSame($widget, $widget->containerAttributes([]));
         $this->assertNotSame($widget, $widget->checkboxAttributes([]));
+        $this->assertNotSame($widget, $widget->addCheckboxAttributes([]));
         $this->assertNotSame($widget, $widget->replaceCheckboxAttributes([]));
         $this->assertNotSame($widget, $widget->individualInputAttributes([]));
         $this->assertNotSame($widget, $widget->replaceIndividualInputAttributes([]));

--- a/tests/common/Widget/CheckboxListTest.php
+++ b/tests/common/Widget/CheckboxListTest.php
@@ -664,8 +664,11 @@ final class CheckboxListTest extends TestCase
                 ->itemFormatter(function (CheckboxItem $item): string {
                     return '<div>' .
                         $item->index . ') ' .
-                        Html::checkbox($item->checkboxAttributes['name'], $item->checkboxAttributes['value'])
-                            ->attributes($item->checkboxAttributes)
+                        Html::checkbox(
+                            $item->checkboxAttributes['name'],
+                            $item->checkboxAttributes['value'],
+                            $item->checkboxAttributes
+                        )
                             ->checked($item->checked)
                             ->label($item->label) .
                         '</div>';

--- a/tests/common/Widget/CheckboxListTest.php
+++ b/tests/common/Widget/CheckboxListTest.php
@@ -154,7 +154,7 @@ final class CheckboxListTest extends TestCase
         );
     }
 
-    public function testIndividualInputAttributes(): void
+    public function testAddIndividualInputAttributes(): void
     {
         $this->assertSame(
             '<label><input type="checkbox" class="red" name="test[]" value="1"> One</label>' . "\n" .
@@ -167,7 +167,7 @@ final class CheckboxListTest extends TestCase
                     3 => 'Three',
                 ])
                 ->replaceCheckboxAttributes(['class' => 'red'])
-                ->individualInputAttributes([
+                ->addIndividualInputAttributes([
                     2 => ['class' => 'blue'],
                     3 => ['class' => 'green'],
                 ])
@@ -189,7 +189,7 @@ final class CheckboxListTest extends TestCase
                 ])
                 ->uncheckValue(0)
                 ->replaceCheckboxAttributes(['class' => 'red'])
-                ->individualInputAttributes([
+                ->replaceIndividualInputAttributes([
                     0 => ['class' => 'blue'],
                 ])
                 ->withoutContainer()
@@ -210,11 +210,11 @@ final class CheckboxListTest extends TestCase
                     3 => 'Three',
                 ])
                 ->replaceCheckboxAttributes(['class' => 'red'])
-                ->individualInputAttributes([
+                ->addIndividualInputAttributes([
                     2 => ['class' => 'blue'],
                     3 => ['class' => 'green'],
                 ])
-                ->individualInputAttributes([
+                ->addIndividualInputAttributes([
                     1 => ['class' => 'yellow'],
                     2 => ['class' => 'cyan'],
                 ])
@@ -236,7 +236,7 @@ final class CheckboxListTest extends TestCase
                     3 => 'Three',
                 ])
                 ->replaceCheckboxAttributes(['class' => 'red'])
-                ->individualInputAttributes([
+                ->addIndividualInputAttributes([
                     2 => ['class' => 'blue'],
                     3 => ['class' => 'green'],
                 ])
@@ -697,6 +697,7 @@ final class CheckboxListTest extends TestCase
         $this->assertNotSame($widget, $widget->addCheckboxAttributes([]));
         $this->assertNotSame($widget, $widget->replaceCheckboxAttributes([]));
         $this->assertNotSame($widget, $widget->individualInputAttributes([]));
+        $this->assertNotSame($widget, $widget->addIndividualInputAttributes([]));
         $this->assertNotSame($widget, $widget->replaceIndividualInputAttributes([]));
         $this->assertNotSame($widget, $widget->items([]));
         $this->assertNotSame($widget, $widget->itemsFromValues([]));

--- a/tests/common/Widget/RadioListTest.php
+++ b/tests/common/Widget/RadioListTest.php
@@ -625,8 +625,11 @@ final class RadioListTest extends TestCase
                 ->itemFormatter(function (RadioItem $item): string {
                     return '<div>' .
                         $item->index . ') ' .
-                        Html::radio($item->radioAttributes['name'], $item->radioAttributes['value'])
-                            ->attributes($item->radioAttributes)
+                        Html::radio(
+                            $item->radioAttributes['name'],
+                            $item->radioAttributes['value'],
+                            $item->radioAttributes
+                        )
                             ->checked($item->checked)
                             ->label($item->label) .
                         '</div>';

--- a/tests/common/Widget/RadioListTest.php
+++ b/tests/common/Widget/RadioListTest.php
@@ -111,7 +111,7 @@ final class RadioListTest extends TestCase
                     1 => 'One',
                     2 => 'Two',
                 ])
-                ->radioAttributes(['class' => 'red'])
+                ->replaceRadioAttributes(['class' => 'red'])
                 ->withoutContainer()
                 ->render(),
         );
@@ -128,7 +128,7 @@ final class RadioListTest extends TestCase
                     2 => 'Two',
                 ])
                 ->readonly()
-                ->radioAttributes(['class' => 'red'])
+                ->addRadioAttributes(['class' => 'red'])
                 ->withoutContainer()
                 ->render(),
         );
@@ -163,7 +163,7 @@ final class RadioListTest extends TestCase
                     2 => 'Two',
                     3 => 'Three',
                 ])
-                ->radioAttributes(['class' => 'red'])
+                ->replaceRadioAttributes(['class' => 'red'])
                 ->individualInputAttributes([
                     2 => ['class' => 'blue'],
                     3 => ['class' => 'green'],
@@ -185,7 +185,7 @@ final class RadioListTest extends TestCase
                     2 => 'Two',
                 ])
                 ->uncheckValue(0)
-                ->radioAttributes(['class' => 'red'])
+                ->replaceRadioAttributes(['class' => 'red'])
                 ->individualInputAttributes([
                     0 => ['class' => 'blue'],
                 ])
@@ -206,7 +206,7 @@ final class RadioListTest extends TestCase
                     2 => 'Two',
                     3 => 'Three',
                 ])
-                ->radioAttributes(['class' => 'red'])
+                ->replaceRadioAttributes(['class' => 'red'])
                 ->individualInputAttributes([
                     2 => ['class' => 'blue'],
                     3 => ['class' => 'green'],
@@ -232,7 +232,7 @@ final class RadioListTest extends TestCase
                     2 => 'Two',
                     3 => 'Three',
                 ])
-                ->radioAttributes(['class' => 'red'])
+                ->replaceRadioAttributes(['class' => 'red'])
                 ->individualInputAttributes([
                     2 => ['class' => 'blue'],
                     3 => ['class' => 'green'],
@@ -655,6 +655,7 @@ final class RadioListTest extends TestCase
         $this->assertNotSame($widget, $widget->containerTag(''));
         $this->assertNotSame($widget, $widget->containerAttributes([]));
         $this->assertNotSame($widget, $widget->radioAttributes([]));
+        $this->assertNotSame($widget, $widget->addRadioAttributes([]));
         $this->assertNotSame($widget, $widget->replaceRadioAttributes([]));
         $this->assertNotSame($widget, $widget->individualInputAttributes([]));
         $this->assertNotSame($widget, $widget->replaceIndividualInputAttributes([]));

--- a/tests/common/Widget/RadioListTest.php
+++ b/tests/common/Widget/RadioListTest.php
@@ -164,7 +164,7 @@ final class RadioListTest extends TestCase
                     3 => 'Three',
                 ])
                 ->replaceRadioAttributes(['class' => 'red'])
-                ->individualInputAttributes([
+                ->replaceIndividualInputAttributes([
                     2 => ['class' => 'blue'],
                     3 => ['class' => 'green'],
                 ])
@@ -186,7 +186,7 @@ final class RadioListTest extends TestCase
                 ])
                 ->uncheckValue(0)
                 ->replaceRadioAttributes(['class' => 'red'])
-                ->individualInputAttributes([
+                ->replaceIndividualInputAttributes([
                     0 => ['class' => 'blue'],
                 ])
                 ->withoutContainer()
@@ -207,11 +207,11 @@ final class RadioListTest extends TestCase
                     3 => 'Three',
                 ])
                 ->replaceRadioAttributes(['class' => 'red'])
-                ->individualInputAttributes([
+                ->addIndividualInputAttributes([
                     2 => ['class' => 'blue'],
                     3 => ['class' => 'green'],
                 ])
-                ->individualInputAttributes([
+                ->addIndividualInputAttributes([
                     1 => ['class' => 'yellow'],
                     2 => ['class' => 'cyan'],
                 ])
@@ -233,7 +233,7 @@ final class RadioListTest extends TestCase
                     3 => 'Three',
                 ])
                 ->replaceRadioAttributes(['class' => 'red'])
-                ->individualInputAttributes([
+                ->addIndividualInputAttributes([
                     2 => ['class' => 'blue'],
                     3 => ['class' => 'green'],
                 ])
@@ -658,6 +658,7 @@ final class RadioListTest extends TestCase
         $this->assertNotSame($widget, $widget->addRadioAttributes([]));
         $this->assertNotSame($widget, $widget->replaceRadioAttributes([]));
         $this->assertNotSame($widget, $widget->individualInputAttributes([]));
+        $this->assertNotSame($widget, $widget->addIndividualInputAttributes([]));
         $this->assertNotSame($widget, $widget->replaceIndividualInputAttributes([]));
         $this->assertNotSame($widget, $widget->items([]));
         $this->assertNotSame($widget, $widget->itemsFromValues([]));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #122 

- [x] `Tag::attributes()`
- [x]  `ButtonGroup::buttonAttributes()`
- [x]  `RadioList::radioAttributes()`
- [x]  `RadioList::individualInputAttributes()`
- [x] `CheckboxList::checkboxAttributes()`
- [x] `CheckboxList::individualInputAttributes()`
- [x] `File::uncheckInputAttributes()`
- [x] `Range::outputAttributes()`