### PR TITLE
Remove `Tag::class()` and rename `Tag::replaceClass()` to `Tag::class()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.5.1 under development
 
-- no changes in this release.
+- Chg #136: Remove `Tag::class()` and rename `Tag::replaceClass()` to `Tag::class()` (@vjik)
 
 ## 2.5.0 July 09, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Chg #136: Remove `Tag::class()` and rename `Tag::replaceClass()` to `Tag::class()` (@vjik)
 - Chg #135: Raise `yiisoft/arrays` version to `^2.0` (@vjik)
+- Enh #133: Raise minimum PHP version to 8.0 and refactor code (@xepozz, @vjik)
 
 ## 2.5.0 July 09, 2022
 

--- a/src/Tag/Base/Tag.php
+++ b/src/Tag/Base/Tag.php
@@ -109,21 +109,6 @@ abstract class Tag implements NoEncodeStringableInterface, Stringable
      * @param string|null ...$class One or many CSS classes.
      *
      * @return static
-     *
-     * @deprecated Use {@see addClass()} or {@see replaceClass()} instead. In the next major version `replaceClass()`
-     * method will be renamed to `class()`.
-     */
-    final public function class(?string ...$class): self
-    {
-        return $this->addClass(...$class);
-    }
-
-    /**
-     * Add one or more CSS classes to the tag.
-     *
-     * @param string|null ...$class One or many CSS classes.
-     *
-     * @return static
      */
     final public function addClass(?string ...$class): self
     {
@@ -142,7 +127,7 @@ abstract class Tag implements NoEncodeStringableInterface, Stringable
      *
      * @return static
      */
-    final public function replaceClass(?string ...$class): self
+    final public function class(?string ...$class): self
     {
         $new = clone $this;
         $new->attributes['class'] = array_filter($class, static fn ($c) => $c !== null);

--- a/tests/common/Tag/BTest.php
+++ b/tests/common/Tag/BTest.php
@@ -14,7 +14,7 @@ final class BTest extends TestCase
         $this->assertSame(
             '<b class="red">Hello</b>',
             (string)B::tag()
-                ->replaceClass('red')
+                ->class('red')
                 ->content('Hello')
         );
     }

--- a/tests/common/Tag/Base/TagTest.php
+++ b/tests/common/Tag/Base/TagTest.php
@@ -71,7 +71,7 @@ final class TagTest extends TestCase
             '<test id="color" class="green">',
             TestTag::tag()
                 ->id('color')
-                ->replaceClass('red')
+                ->class('red')
                 ->addAttributes(['class' => 'green'])
                 ->render(),
         );
@@ -83,7 +83,7 @@ final class TagTest extends TestCase
             '<test class="green">',
             TestTag::tag()
                 ->id('color')
-                ->replaceClass('red')
+                ->class('red')
                 ->replaceAttributes(['class' => 'green'])
                 ->render(),
         );
@@ -94,7 +94,7 @@ final class TagTest extends TestCase
         $this->assertSame(
             '<test id="color" class="red">',
             TestTag::tag()
-                ->replaceClass('red')
+                ->class('red')
                 ->unionAttributes(['class' => 'green', 'id' => 'color'])
                 ->render(),
         );
@@ -135,7 +135,7 @@ final class TagTest extends TestCase
         $this->assertSame($expected, (string)TestTag::tag()->id($id));
     }
 
-    public function dataClass(): array
+    public function dataAddClass(): array
     {
         return [
             ['<test class="main">', []],
@@ -147,7 +147,7 @@ final class TagTest extends TestCase
     }
 
     /**
-     * @dataProvider dataClass
+     * @dataProvider dataAddClass
      *
      * @param string[] $class
      */
@@ -175,7 +175,7 @@ final class TagTest extends TestCase
         $this->assertSame($expected, (string)TestTag::tag()->addClass($class));
     }
 
-    public function dataReplaceClass(): array
+    public function dataClass(): array
     {
         return [
             ['<test>', []],
@@ -188,15 +188,15 @@ final class TagTest extends TestCase
     }
 
     /**
-     * @dataProvider dataReplaceClass
+     * @dataProvider dataClass
      *
      * @param string[] $class
      */
-    public function testReplaceClass(string $expected, array $class): void
+    public function testClass(string $expected, array $class): void
     {
         $this->assertSame($expected, (string)TestTag::tag()
-            ->replaceClass('red')
-            ->replaceClass(...$class));
+            ->class('red')
+            ->class(...$class));
     }
 
     public function testImmutability(): void
@@ -208,8 +208,7 @@ final class TagTest extends TestCase
         $this->assertNotSame($tag, $tag->unionAttributes([]));
         $this->assertNotSame($tag, $tag->attribute('id', null));
         $this->assertNotSame($tag, $tag->id(null));
-        $this->assertNotSame($tag, $tag->class('test'));
         $this->assertNotSame($tag, $tag->addClass('test'));
-        $this->assertNotSame($tag, $tag->replaceClass('test'));
+        $this->assertNotSame($tag, $tag->class('test'));
     }
 }

--- a/tests/common/Tag/ColgroupTest.php
+++ b/tests/common/Tag/ColgroupTest.php
@@ -23,10 +23,10 @@ final class ColgroupTest extends TestCase
                     Col::tag(),
                     Col::tag()
                         ->span(2)
-                        ->replaceClass('red'),
+                        ->class('red'),
                     Col::tag()
                         ->span(2)
-                        ->replaceClass('blue'),
+                        ->class('blue'),
                 )
                 ->render()
         );

--- a/tests/common/Tag/DivTest.php
+++ b/tests/common/Tag/DivTest.php
@@ -14,7 +14,7 @@ final class DivTest extends TestCase
         $this->assertSame(
             '<div class="red">Hello</div>',
             (string)Div::tag()
-                ->replaceClass('red')
+                ->class('red')
                 ->content('Hello')
         );
     }

--- a/tests/common/Tag/EmTest.php
+++ b/tests/common/Tag/EmTest.php
@@ -14,7 +14,7 @@ final class EmTest extends TestCase
         $this->assertSame(
             '<em class="red">Hello</em>',
             (string)Em::tag()
-                ->replaceClass('red')
+                ->class('red')
                 ->content('Hello')
         );
     }

--- a/tests/common/Tag/H1Test.php
+++ b/tests/common/Tag/H1Test.php
@@ -14,7 +14,7 @@ final class H1Test extends TestCase
         $this->assertSame(
             '<h1 class="red">Hello</h1>',
             (string) H1::tag()
-                ->replaceClass('red')
+                ->class('red')
                 ->content('Hello')
         );
     }

--- a/tests/common/Tag/H2Test.php
+++ b/tests/common/Tag/H2Test.php
@@ -14,7 +14,7 @@ final class H2Test extends TestCase
         $this->assertSame(
             '<h2 class="red">Hello</h2>',
             (string) H2::tag()
-                ->replaceClass('red')
+                ->class('red')
                 ->content('Hello')
         );
     }

--- a/tests/common/Tag/H3Test.php
+++ b/tests/common/Tag/H3Test.php
@@ -14,7 +14,7 @@ final class H3Test extends TestCase
         $this->assertSame(
             '<h3 class="red">Hello</h3>',
             (string) H3::tag()
-                ->replaceClass('red')
+                ->class('red')
                 ->content('Hello')
         );
     }

--- a/tests/common/Tag/H4Test.php
+++ b/tests/common/Tag/H4Test.php
@@ -14,7 +14,7 @@ final class H4Test extends TestCase
         $this->assertSame(
             '<h4 class="red">Hello</h4>',
             (string) H4::tag()
-                ->replaceClass('red')
+                ->class('red')
                 ->content('Hello')
         );
     }

--- a/tests/common/Tag/H5Test.php
+++ b/tests/common/Tag/H5Test.php
@@ -14,7 +14,7 @@ final class H5Test extends TestCase
         $this->assertSame(
             '<h5 class="red">Hello</h5>',
             (string) H5::tag()
-                ->replaceClass('red')
+                ->class('red')
                 ->content('Hello')
         );
     }

--- a/tests/common/Tag/H6Test.php
+++ b/tests/common/Tag/H6Test.php
@@ -14,7 +14,7 @@ final class H6Test extends TestCase
         $this->assertSame(
             '<h6 class="red">Hello</h6>',
             (string) H6::tag()
-                ->replaceClass('red')
+                ->class('red')
                 ->content('Hello')
         );
     }

--- a/tests/common/Tag/ITest.php
+++ b/tests/common/Tag/ITest.php
@@ -14,7 +14,7 @@ final class ITest extends TestCase
         $this->assertSame(
             '<i class="red">Hello</i>',
             (string)I::tag()
-                ->replaceClass('red')
+                ->class('red')
                 ->content('Hello')
         );
     }

--- a/tests/common/Tag/LiTest.php
+++ b/tests/common/Tag/LiTest.php
@@ -14,7 +14,7 @@ final class LiTest extends TestCase
         $this->assertSame(
             '<li class="red">Hello</li>',
             (string)Li::tag()
-                ->replaceClass('red')
+                ->class('red')
                 ->content('Hello')
         );
     }

--- a/tests/common/Tag/PTest.php
+++ b/tests/common/Tag/PTest.php
@@ -14,7 +14,7 @@ final class PTest extends TestCase
         $this->assertSame(
             '<p class="red">Hello</p>',
             (string)P::tag()
-                ->replaceClass('red')
+                ->class('red')
                 ->content('Hello')
         );
     }

--- a/tests/common/Tag/SpanTest.php
+++ b/tests/common/Tag/SpanTest.php
@@ -14,7 +14,7 @@ final class SpanTest extends TestCase
         $this->assertSame(
             '<span class="red">Hello</span>',
             (string)Span::tag()
-                ->replaceClass('red')
+                ->class('red')
                 ->content('Hello')
         );
     }

--- a/tests/common/Tag/StrongTest.php
+++ b/tests/common/Tag/StrongTest.php
@@ -14,7 +14,7 @@ final class StrongTest extends TestCase
         $this->assertSame(
             '<strong class="red">Hello</strong>',
             (string)Strong::tag()
-                ->replaceClass('red')
+                ->class('red')
                 ->content('Hello')
         );
     }

--- a/tests/common/Tag/TableTest.php
+++ b/tests/common/Tag/TableTest.php
@@ -179,7 +179,7 @@ class TableTest extends TestCase
     {
         $tag = Table::tag()->body(
             Tbody::tag(),
-            Tbody::tag()->replaceClass('red'),
+            Tbody::tag()->class('red'),
         );
 
         $this->assertSame(
@@ -198,8 +198,8 @@ class TableTest extends TestCase
                 Tbody::tag(),
             )
             ->addBody(
-                Tbody::tag()->replaceClass('red'),
-                Tbody::tag()->replaceClass('green'),
+                Tbody::tag()->class('red'),
+                Tbody::tag()->class('green'),
             );
 
         $this->assertSame(

--- a/tests/common/Tag/TbodyTest.php
+++ b/tests/common/Tag/TbodyTest.php
@@ -24,7 +24,7 @@ final class TbodyTest extends TestCase
             '</tr>' . "\n" .
             '</tbody>',
             Tbody::tag()
-                ->replaceClass('gray')
+                ->class('gray')
                 ->rows(
                     Tr::tag()->dataStrings(['A', 'B']),
                     Tr::tag()->dataStrings(['C', 'D']),

--- a/tests/common/Tag/TfootTest.php
+++ b/tests/common/Tag/TfootTest.php
@@ -24,7 +24,7 @@ final class TfootTest extends TestCase
             '</tr>' . "\n" .
             '</tfoot>',
             Tfoot::tag()
-                ->replaceClass('gray')
+                ->class('gray')
                 ->rows(
                     Tr::tag()->dataStrings(['A', 'B']),
                     Tr::tag()->dataStrings(['C', 'D']),

--- a/tests/common/Tag/TheadTest.php
+++ b/tests/common/Tag/TheadTest.php
@@ -24,7 +24,7 @@ final class TheadTest extends TestCase
             '</tr>' . "\n" .
             '</thead>',
             Thead::tag()
-                ->replaceClass('gray')
+                ->class('gray')
                 ->rows(
                     Tr::tag()->dataStrings(['A', 'B']),
                     Tr::tag()->dataStrings(['C', 'D']),

--- a/tests/common/Tag/TrTest.php
+++ b/tests/common/Tag/TrTest.php
@@ -20,7 +20,7 @@ class TrTest extends TestCase
             '<td class="cell">Three</td>' . "\n" .
             '</tr>',
             Tr::tag()
-                ->replaceClass('row')
+                ->class('row')
                 ->dataStrings(['One', 'Two', 'Three'], ['class' => 'cell'])
                 ->render()
         );

--- a/tests/common/Widget/ButtonGroupTest.php
+++ b/tests/common/Widget/ButtonGroupTest.php
@@ -216,7 +216,7 @@ final class ButtonGroupTest extends TestCase
     {
         $widget = ButtonGroup::create()
             ->buttons(
-                Html::button('Show')->replaceClass('red'),
+                Html::button('Show')->class('red'),
                 Html::button('Hide'),
             )
             ->replaceButtonAttributes(['class' => 'base']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #124 
