### PR TITLE
Remove methods `*attributes()` and rename `replace*Attributes()` to `*attributes()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,20 @@
 - Chg #136: Remove `Tag::class()` and rename `Tag::replaceClass()` to `Tag::class()` (@vjik)
 - Chg #135: Raise `yiisoft/arrays` version to `^2.0` (@vjik)
 - Enh #133: Raise minimum PHP version to 8.0 and refactor code (@xepozz, @vjik)
-- Chg #140: Remove `Html::fileInput()` and `Input::file()`. Rename `Input::fileControl()` to `Input::file()` (@vjik)
+- Chg #140: Remove `Html::fileInput()` and `Input::file()`, rename `Input::fileControl()` to `Input::file()` (@vjik)
+- Chg #141: `Tag` class: remove `attributes()` method and rename `replaceAttributes()` to `attributes()` (@vjik)
+- Chg #141: `Range` class: remove `outputAttributes()` method and rename `replaceOutputAttributes()` 
+  to `outputAttributes()` (@vjik)
+- Chg #141: `File` class: remove `uncheckInputAttributes()` method and rename `replaceUncheckInputAttributes()` 
+  to `uncheckInputAttributes()` (@vjik)
+- Chg #141: `ButtonGroup` class: remove `buttonAttributes()` method and rename `replaceButtonAttributes()`
+  to `buttonAttributes()` (@vjik)
+- Chg #141: `CheckboxList`: remove `individualInputAttributes()` and `checkboxAttributes()` methods,
+  rename `replaceIndividualInputAttributes()` to `individualInputAttributes()` and `replaceCheckboxAttributes()`
+  to `checkboxAttributes()` (@vjik)
+- Chg #141: `RadioList` class: remove `individualInputAttributes()` and `radioAttributes()` methods, 
+  rename `replaceIndividualInputAttributes()` to `individualInputAttributes()` and `replaceRadioAttributes()` 
+  to `radioAttributes()` (@vjik)
 
 ## 2.5.0 July 09, 2022
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ echo \Yiisoft\Html\Widget\ButtonGroup::create()
 	    \Yiisoft\Html\Html::resetButton('Send'),
 	)
 	->containerAttributes(['class' => 'actions'])
-	->replaceButtonAttributes(['form' => 'CreatePost']);
+	->buttonAttributes(['form' => 'CreatePost']);
 ```
 
 Result will be:

--- a/src/Html.php
+++ b/src/Html.php
@@ -290,7 +290,7 @@ final class Html
             $tag = $tag->content($content);
         }
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $tag;
     }
@@ -313,7 +313,7 @@ final class Html
             $tag = $tag->content($content);
         }
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $tag;
     }
@@ -332,7 +332,7 @@ final class Html
     {
         $tag = CustomTag::name($name)->void();
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $tag;
     }
@@ -375,7 +375,7 @@ final class Html
             $tag = $tag->content($content);
         }
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $tag;
     }
@@ -393,7 +393,7 @@ final class Html
             $tag = $tag->content($content);
         }
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $tag;
     }
@@ -419,7 +419,7 @@ final class Html
     {
         $tag = Title::tag();
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -433,7 +433,7 @@ final class Html
     {
         $tag = Meta::tag();
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $tag;
     }
@@ -448,7 +448,7 @@ final class Html
     {
         $tag = Link::tag();
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         if ($url !== null) {
             $tag = $tag->url($url);
@@ -498,7 +498,7 @@ final class Html
     {
         $tag = A::tag();
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         if ($content !== '') {
             $tag = $tag->content($content);
@@ -554,7 +554,7 @@ final class Html
     {
         $tag = Fieldset::tag();
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $tag;
     }
@@ -576,7 +576,7 @@ final class Html
             $attributes['method'] = $method;
         }
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $tag;
     }
@@ -613,7 +613,7 @@ final class Html
             $tag = $tag->content($content);
         }
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $tag;
     }
@@ -940,7 +940,7 @@ final class Html
     {
         $tag = Div::tag();
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -955,7 +955,7 @@ final class Html
     {
         $tag = Span::tag();
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -970,7 +970,7 @@ final class Html
     {
         $tag = Em::tag();
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -985,7 +985,7 @@ final class Html
     {
         $tag = Strong::tag();
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1000,7 +1000,7 @@ final class Html
     {
         $tag = B::tag();
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1015,7 +1015,7 @@ final class Html
     {
         $tag = I::tag();
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1030,7 +1030,7 @@ final class Html
     {
         $tag = H1::tag();
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1045,7 +1045,7 @@ final class Html
     {
         $tag = H2::tag();
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1060,7 +1060,7 @@ final class Html
     {
         $tag = H3::tag();
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1075,7 +1075,7 @@ final class Html
     {
         $tag = H4::tag();
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1090,7 +1090,7 @@ final class Html
     {
         $tag = H5::tag();
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1105,7 +1105,7 @@ final class Html
     {
         $tag = H6::tag();
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1120,7 +1120,7 @@ final class Html
     {
         $tag = P::tag();
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1162,7 +1162,7 @@ final class Html
     {
         $tag = Datalist::tag();
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $tag;
     }
@@ -1180,7 +1180,7 @@ final class Html
             $tag = $tag->content($content);
         }
         if ($attributes !== []) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $tag;
     }
@@ -1193,7 +1193,7 @@ final class Html
     public static function col(array $attributes = []): Col
     {
         $tag = Col::tag();
-        return $attributes === [] ? $tag : $tag->replaceAttributes($attributes);
+        return $attributes === [] ? $tag : $tag->attributes($attributes);
     }
 
     /**
@@ -1204,7 +1204,7 @@ final class Html
     public static function colgroup(array $attributes = []): Colgroup
     {
         $tag = Colgroup::tag();
-        return $attributes === [] ? $tag : $tag->replaceAttributes($attributes);
+        return $attributes === [] ? $tag : $tag->attributes($attributes);
     }
 
     /**
@@ -1215,7 +1215,7 @@ final class Html
     public static function table(array $attributes = []): Table
     {
         $tag = Table::tag();
-        return $attributes === [] ? $tag : $tag->replaceAttributes($attributes);
+        return $attributes === [] ? $tag : $tag->attributes($attributes);
     }
 
     /**
@@ -1226,7 +1226,7 @@ final class Html
     public static function thead(array $attributes = []): Thead
     {
         $tag = Thead::tag();
-        return $attributes === [] ? $tag : $tag->replaceAttributes($attributes);
+        return $attributes === [] ? $tag : $tag->attributes($attributes);
     }
 
     /**
@@ -1237,7 +1237,7 @@ final class Html
     public static function tbody(array $attributes = []): Tbody
     {
         $tag = Tbody::tag();
-        return $attributes === [] ? $tag : $tag->replaceAttributes($attributes);
+        return $attributes === [] ? $tag : $tag->attributes($attributes);
     }
 
     /**
@@ -1248,7 +1248,7 @@ final class Html
     public static function tfoot(array $attributes = []): Tfoot
     {
         $tag = Tfoot::tag();
-        return $attributes === [] ? $tag : $tag->replaceAttributes($attributes);
+        return $attributes === [] ? $tag : $tag->attributes($attributes);
     }
 
     /**
@@ -1259,7 +1259,7 @@ final class Html
     public static function tr(array $attributes = []): Tr
     {
         $tag = Tr::tag();
-        return $attributes === [] ? $tag : $tag->replaceAttributes($attributes);
+        return $attributes === [] ? $tag : $tag->attributes($attributes);
     }
 
     /**
@@ -1275,7 +1275,7 @@ final class Html
             $tag = $tag->content($content);
         }
         if ($attributes !== []) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $tag;
     }
@@ -1293,7 +1293,7 @@ final class Html
             $tag = $tag->content($content);
         }
         if ($attributes !== []) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $tag;
     }
@@ -1357,7 +1357,7 @@ final class Html
     {
         $tag = Body::tag();
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1372,7 +1372,7 @@ final class Html
     {
         $tag = Article::tag();
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1387,7 +1387,7 @@ final class Html
     {
         $tag = Section::tag();
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1402,7 +1402,7 @@ final class Html
     {
         $tag = Nav::tag();
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1417,7 +1417,7 @@ final class Html
     {
         $tag = Aside::tag();
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1432,7 +1432,7 @@ final class Html
     {
         $tag = Hgroup::tag();
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1447,7 +1447,7 @@ final class Html
     {
         $tag = Header::tag();
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1462,7 +1462,7 @@ final class Html
     {
         $tag = Footer::tag();
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }
@@ -1477,7 +1477,7 @@ final class Html
     {
         $tag = Address::tag();
         if (!empty($attributes)) {
-            $tag = $tag->replaceAttributes($attributes);
+            $tag = $tag->attributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
     }

--- a/src/Tag/Base/ListTag.php
+++ b/src/Tag/Base/ListTag.php
@@ -40,7 +40,7 @@ abstract class ListTag extends NormalTag
         $items = array_map(
             static fn (string $string) => Li::tag()
                 ->content($string)
-                ->replaceAttributes($attributes)
+                ->attributes($attributes)
                 ->encode($encode),
             $strings
         );

--- a/src/Tag/Base/Tag.php
+++ b/src/Tag/Base/Tag.php
@@ -22,22 +22,6 @@ abstract class Tag implements NoEncodeStringableInterface, Stringable
      * @param array $attributes Name-value set of attributes.
      *
      * @return static
-     *
-     * @deprecated Use {@see addAttributes()} or {@see replaceAttributes()} instead. In the next major version
-     * `replaceAttributes()` method will be renamed to `attributes()`.
-     */
-    final public function attributes(array $attributes): self
-    {
-        return $this->addAttributes($attributes);
-    }
-
-    /**
-     * Add a set of attributes to existing tag attributes.
-     * Same named attributes are replaced.
-     *
-     * @param array $attributes Name-value set of attributes.
-     *
-     * @return static
      */
     final public function addAttributes(array $attributes): self
     {
@@ -53,7 +37,7 @@ abstract class Tag implements NoEncodeStringableInterface, Stringable
      *
      * @return static
      */
-    final public function replaceAttributes(array $attributes): self
+    final public function attributes(array $attributes): self
     {
         $new = clone $this;
         $new->attributes = $attributes;

--- a/src/Tag/Input/File.php
+++ b/src/Tag/Input/File.php
@@ -26,15 +26,6 @@ final class File extends InputTag
         return $new;
     }
 
-    /**
-     * @deprecated Use {@see addUncheckInputAttributes()} or {@see replaceUncheckInputAttributes()} instead. In the next
-     * major version `replaceUncheckInputAttributes()` method will be renamed to `uncheckInputAttributes()`.
-     */
-    public function uncheckInputAttributes(array $attributes): self
-    {
-        return $this->addUncheckInputAttributes($attributes);
-    }
-
     public function addUncheckInputAttributes(array $attributes): self
     {
         $new = clone $this;
@@ -42,7 +33,7 @@ final class File extends InputTag
         return $new;
     }
 
-    public function replaceUncheckInputAttributes(array $attributes): self
+    public function uncheckInputAttributes(array $attributes): self
     {
         $new = clone $this;
         $new->uncheckInputAttributes = $attributes;

--- a/src/Tag/Input/Range.php
+++ b/src/Tag/Input/Range.php
@@ -97,15 +97,6 @@ final class Range extends InputTag
         return $new;
     }
 
-    /**
-     * @deprecated Use {@see addOutputAttributes()} or {@see replaceOutputAttributes()} instead. In the next major
-     * version `replaceOutputAttributes()` method will be renamed to `outputAttributes()`.
-     */
-    public function outputAttributes(array $attributes): self
-    {
-        return $this->addOutputAttributes($attributes);
-    }
-
     public function addOutputAttributes(array $attributes): self
     {
         $new = clone $this;
@@ -113,7 +104,7 @@ final class Range extends InputTag
         return $new;
     }
 
-    public function replaceOutputAttributes(array $attributes): self
+    public function outputAttributes(array $attributes): self
     {
         $new = clone $this;
         $new->outputAttributes = $attributes;

--- a/src/Tag/Input/Range.php
+++ b/src/Tag/Input/Range.php
@@ -137,7 +137,7 @@ final class Range extends InputTag
         }
 
         return "\n" . CustomTag::name($this->outputTag)
-                ->replaceAttributes($this->outputAttributes)
+                ->attributes($this->outputAttributes)
                 ->content((string) ($this->attributes['value'] ?? '-'))
                 ->id($this->outputId)
                 ->render();

--- a/src/Tag/Optgroup.php
+++ b/src/Tag/Optgroup.php
@@ -35,7 +35,7 @@ final class Optgroup extends NormalTag
         $options = [];
         foreach ($data as $value => $content) {
             $options[] = Option::tag()
-                ->replaceAttributes($optionsAttributes[$value] ?? [])
+                ->attributes($optionsAttributes[$value] ?? [])
                 ->value($value)
                 ->content($content)
                 ->encode($encode);

--- a/src/Tag/Select.php
+++ b/src/Tag/Select.php
@@ -150,7 +150,7 @@ final class Select extends NormalTag
                     ->optionsData($content, $encode, $optionsAttributes);
             } else {
                 $items[] = Option::tag()
-                    ->replaceAttributes($optionsAttributes[$value] ?? [])
+                    ->attributes($optionsAttributes[$value] ?? [])
                     ->value($value)
                     ->content($content)
                     ->encode($encode);

--- a/src/Tag/Tr.php
+++ b/src/Tag/Tr.php
@@ -67,7 +67,7 @@ final class Tr extends NormalTag
         return array_map(
             static fn (string $string) => Td::tag()
                 ->content($string)
-                ->replaceAttributes($attributes)
+                ->attributes($attributes)
                 ->encode($encode),
             $strings
         );
@@ -103,7 +103,7 @@ final class Tr extends NormalTag
         return array_map(
             static fn (string $string) => Th::tag()
                 ->content($string)
-                ->replaceAttributes($attributes)
+                ->attributes($attributes)
                 ->encode($encode),
             $strings
         );

--- a/src/Widget/ButtonGroup.php
+++ b/src/Widget/ButtonGroup.php
@@ -89,15 +89,6 @@ final class ButtonGroup implements NoEncodeStringableInterface, Stringable
         return $this->buttons(...$buttons);
     }
 
-    /**
-     * @deprecated Use {@see addButtonAttributes()} or {@see replaceButtonAttributes()} instead. In the next major
-     * version `replaceButtonAttributes()` method will be renamed to `buttonAttributes()`.
-     */
-    public function buttonAttributes(array $attributes): self
-    {
-        return $this->addButtonAttributes($attributes);
-    }
-
     public function addButtonAttributes(array $attributes): self
     {
         $new = clone $this;
@@ -105,7 +96,7 @@ final class ButtonGroup implements NoEncodeStringableInterface, Stringable
         return $new;
     }
 
-    public function replaceButtonAttributes(array $attributes): self
+    public function buttonAttributes(array $attributes): self
     {
         $new = clone $this;
         $new->buttonAttributes = $attributes;

--- a/src/Widget/CheckboxList/CheckboxList.php
+++ b/src/Widget/CheckboxList/CheckboxList.php
@@ -101,18 +101,6 @@ final class CheckboxList implements NoEncodeStringableInterface, Stringable
 
     /**
      * @param array[] $attributes
-     *
-     * @deprecated Use {@see addIndividualInputAttributes()} or {@see replaceIndividualInputAttributes()} instead. In
-     * the next major version `replaceIndividualInputAttributes()` method will be renamed to
-     * `individualInputAttributes()`.
-     */
-    public function individualInputAttributes(array $attributes): self
-    {
-        return $this->addIndividualInputAttributes($attributes);
-    }
-
-    /**
-     * @param array[] $attributes
      */
     public function addIndividualInputAttributes(array $attributes): self
     {
@@ -124,7 +112,7 @@ final class CheckboxList implements NoEncodeStringableInterface, Stringable
     /**
      * @param array[] $attributes
      */
-    public function replaceIndividualInputAttributes(array $attributes): self
+    public function individualInputAttributes(array $attributes): self
     {
         $new = clone $this;
         $new->individualInputAttributes = $attributes;

--- a/src/Widget/CheckboxList/CheckboxList.php
+++ b/src/Widget/CheckboxList/CheckboxList.php
@@ -85,15 +85,6 @@ final class CheckboxList implements NoEncodeStringableInterface, Stringable
         return $new;
     }
 
-    /**
-     * @deprecated Use {@see addCheckboxAttributes()} or {@see replaceCheckboxAttributes()} instead. In the next major
-     * version `replaceCheckboxAttributes()` method will be renamed to `checkboxAttributes()`.
-     */
-    public function checkboxAttributes(array $attributes): self
-    {
-        return $this->addCheckboxAttributes($attributes);
-    }
-
     public function addCheckboxAttributes(array $attributes): self
     {
         $new = clone $this;
@@ -101,7 +92,7 @@ final class CheckboxList implements NoEncodeStringableInterface, Stringable
         return $new;
     }
 
-    public function replaceCheckboxAttributes(array $attributes): self
+    public function checkboxAttributes(array $attributes): self
     {
         $new = clone $this;
         $new->checkboxAttributes = $attributes;

--- a/src/Widget/RadioList/RadioList.php
+++ b/src/Widget/RadioList/RadioList.php
@@ -94,18 +94,6 @@ final class RadioList implements NoEncodeStringableInterface, Stringable
 
     /**
      * @param array[] $attributes
-     *
-     * @deprecated Use {@see addIndividualInputAttributes()} or {@see replaceIndividualInputAttributes()} instead. In
-     * the next major version `replaceIndividualInputAttributes()` method will be renamed to
-     * `individualInputAttributes()`.
-     */
-    public function individualInputAttributes(array $attributes): self
-    {
-        return $this->addIndividualInputAttributes($attributes);
-    }
-
-    /**
-     * @param array[] $attributes
      */
     public function addIndividualInputAttributes(array $attributes): self
     {
@@ -117,7 +105,7 @@ final class RadioList implements NoEncodeStringableInterface, Stringable
     /**
      * @param array[] $attributes
      */
-    public function replaceIndividualInputAttributes(array $attributes): self
+    public function individualInputAttributes(array $attributes): self
     {
         $new = clone $this;
         $new->individualInputAttributes = $attributes;

--- a/src/Widget/RadioList/RadioList.php
+++ b/src/Widget/RadioList/RadioList.php
@@ -78,15 +78,6 @@ final class RadioList implements NoEncodeStringableInterface, Stringable
         return $new;
     }
 
-    /**
-     * @deprecated Use {@see addRadioAttributes()} or {@see replaceRadioAttributes()} instead. In the next major version
-     * `replaceRadioAttributes()` method will be renamed to `radioAttributes()`.
-     */
-    public function radioAttributes(array $attributes): self
-    {
-        return $this->addRadioAttributes($attributes);
-    }
-
     public function addRadioAttributes(array $attributes): self
     {
         $new = clone $this;
@@ -94,7 +85,7 @@ final class RadioList implements NoEncodeStringableInterface, Stringable
         return $new;
     }
 
-    public function replaceRadioAttributes(array $attributes): self
+    public function radioAttributes(array $attributes): self
     {
         $new = clone $this;
         $new->radioAttributes = $attributes;

--- a/tests/common/Tag/Base/TagTest.php
+++ b/tests/common/Tag/Base/TagTest.php
@@ -61,8 +61,8 @@ final class TagTest extends TestCase
      */
     public function testAttributes(string $expected, array $attributes): void
     {
-        $this->assertSame($expected, (string)TestTag::tag()->addAttributes($attributes));
-        $this->assertSame($expected, (string)TestTag::tag()->replaceAttributes($attributes));
+        $this->assertSame($expected, (string) TestTag::tag()->addAttributes($attributes));
+        $this->assertSame($expected, (string) TestTag::tag()->attributes($attributes));
     }
 
     public function testAttributesMerge(): void
@@ -84,7 +84,7 @@ final class TagTest extends TestCase
             TestTag::tag()
                 ->id('color')
                 ->class('red')
-                ->replaceAttributes(['class' => 'green'])
+                ->attributes(['class' => 'green'])
                 ->render(),
         );
     }
@@ -202,9 +202,8 @@ final class TagTest extends TestCase
     public function testImmutability(): void
     {
         $tag = TestTag::tag();
-        $this->assertNotSame($tag, $tag->attributes([]));
         $this->assertNotSame($tag, $tag->addAttributes([]));
-        $this->assertNotSame($tag, $tag->replaceAttributes([]));
+        $this->assertNotSame($tag, $tag->attributes([]));
         $this->assertNotSame($tag, $tag->unionAttributes([]));
         $this->assertNotSame($tag, $tag->attribute('id', null));
         $this->assertNotSame($tag, $tag->id(null));

--- a/tests/common/Tag/BodyTest.php
+++ b/tests/common/Tag/BodyTest.php
@@ -22,7 +22,7 @@ final class BodyTest extends TestCase
         $this->assertSame(
             '<body onafterprint="alert(123);" style="font-size:20px;">Welcome Back!</body>',
             (string) Body::tag()
-                ->replaceAttributes([
+                ->attributes([
                     'onafterprint' => 'alert(123);',
                     'style' => 'font-size:20px;',
                 ])

--- a/tests/common/Tag/FieldsetTest.php
+++ b/tests/common/Tag/FieldsetTest.php
@@ -89,7 +89,7 @@ final class FieldsetTest extends TestCase
                 HTML,
                 Legend::tag()
                     ->content('Hello')
-                    ->replaceAttributes(['id' => 'MyLegend']),
+                    ->attributes(['id' => 'MyLegend']),
             ],
         ];
     }

--- a/tests/common/Tag/Input/FileTest.php
+++ b/tests/common/Tag/Input/FileTest.php
@@ -104,7 +104,7 @@ final class FileTest extends TestCase
             ->name('avatar')
             ->uncheckValue(7)
             ->addUncheckInputAttributes(['id' => 'FileHidden'])
-            ->replaceUncheckInputAttributes(['data-key' => '100'])
+            ->uncheckInputAttributes(['data-key' => '100'])
             ->form('post')
             ->render();
 
@@ -187,9 +187,8 @@ final class FileTest extends TestCase
         $tag = File::tag();
 
         $this->assertNotSame($tag, $tag->uncheckValue(null));
-        $this->assertNotSame($tag, $tag->uncheckInputAttributes([]));
         $this->assertNotSame($tag, $tag->addUncheckInputAttributes([]));
-        $this->assertNotSame($tag, $tag->replaceUncheckInputAttributes([]));
+        $this->assertNotSame($tag, $tag->uncheckInputAttributes([]));
         $this->assertNotSame($tag, $tag->accept(null));
         $this->assertNotSame($tag, $tag->multiple());
     }

--- a/tests/common/Tag/Input/RangeTest.php
+++ b/tests/common/Tag/Input/RangeTest.php
@@ -144,7 +144,7 @@ final class RangeTest extends TestCase
         $tag = Range::tag()
             ->showOutput()
             ->addOutputAttributes(['class' => 'red'])
-            ->replaceOutputAttributes(['id' => 'UID']);
+            ->outputAttributes(['id' => 'UID']);
 
         $this->assertSame(
             '<input type="range" ' .
@@ -158,7 +158,7 @@ final class RangeTest extends TestCase
     {
         $tag = Range::tag()
             ->showOutput()
-            ->replaceOutputAttributes(['id' => 'UID']);
+            ->outputAttributes(['id' => 'UID']);
 
         $this->assertMatchesRegularExpression(
             '~<input type="range" ' .
@@ -186,7 +186,7 @@ final class RangeTest extends TestCase
     {
         $tag = Range::tag()
             ->showOutput()
-            ->replaceOutputAttributes(['class' => 'red']);
+            ->outputAttributes(['class' => 'red']);
 
         $this->assertMatchesRegularExpression(
             '~<input type="range" ' .
@@ -229,8 +229,7 @@ final class RangeTest extends TestCase
         $this->assertNotSame($tag, $tag->list(null));
         $this->assertNotSame($tag, $tag->showOutput());
         $this->assertNotSame($tag, $tag->outputTag('b'));
-        $this->assertNotSame($tag, $tag->outputAttributes([]));
         $this->assertNotSame($tag, $tag->addOutputAttributes([]));
-        $this->assertNotSame($tag, $tag->replaceOutputAttributes([]));
+        $this->assertNotSame($tag, $tag->outputAttributes([]));
     }
 }

--- a/tests/common/Widget/ButtonGroupTest.php
+++ b/tests/common/Widget/ButtonGroupTest.php
@@ -219,7 +219,7 @@ final class ButtonGroupTest extends TestCase
                 Html::button('Show')->class('red'),
                 Html::button('Hide'),
             )
-            ->replaceButtonAttributes(['class' => 'base']);
+            ->buttonAttributes(['class' => 'base']);
 
         $this->assertStringContainsStringIgnoringLineEndings(
             <<<HTML
@@ -240,7 +240,7 @@ final class ButtonGroupTest extends TestCase
                 Html::button('Hide'),
             )
             ->disabled()
-            ->replaceButtonAttributes(['class' => 'base']);
+            ->buttonAttributes(['class' => 'base']);
 
         $this->assertStringContainsStringIgnoringLineEndings(
             <<<HTML
@@ -371,9 +371,8 @@ final class ButtonGroupTest extends TestCase
         $this->assertNotSame($widget, $widget->containerAttributes([]));
         $this->assertNotSame($widget, $widget->buttons());
         $this->assertNotSame($widget, $widget->buttonsData([]));
-        $this->assertNotSame($widget, $widget->buttonAttributes([]));
         $this->assertNotSame($widget, $widget->addButtonAttributes([]));
-        $this->assertNotSame($widget, $widget->replaceButtonAttributes([]));
+        $this->assertNotSame($widget, $widget->buttonAttributes([]));
         $this->assertNotSame($widget, $widget->disabled());
         $this->assertNotSame($widget, $widget->form(null));
         $this->assertNotSame($widget, $widget->separator(''));

--- a/tests/common/Widget/CheckboxListTest.php
+++ b/tests/common/Widget/CheckboxListTest.php
@@ -189,7 +189,7 @@ final class CheckboxListTest extends TestCase
                 ])
                 ->uncheckValue(0)
                 ->checkboxAttributes(['class' => 'red'])
-                ->replaceIndividualInputAttributes([
+                ->individualInputAttributes([
                     0 => ['class' => 'blue'],
                 ])
                 ->withoutContainer()
@@ -240,7 +240,7 @@ final class CheckboxListTest extends TestCase
                     2 => ['class' => 'blue'],
                     3 => ['class' => 'green'],
                 ])
-                ->replaceIndividualInputAttributes([
+                ->individualInputAttributes([
                     1 => ['class' => 'yellow'],
                 ])
                 ->withoutContainer()
@@ -693,9 +693,8 @@ final class CheckboxListTest extends TestCase
         $this->assertNotSame($widget, $widget->containerAttributes([]));
         $this->assertNotSame($widget, $widget->addCheckboxAttributes([]));
         $this->assertNotSame($widget, $widget->checkboxAttributes([]));
-        $this->assertNotSame($widget, $widget->individualInputAttributes([]));
         $this->assertNotSame($widget, $widget->addIndividualInputAttributes([]));
-        $this->assertNotSame($widget, $widget->replaceIndividualInputAttributes([]));
+        $this->assertNotSame($widget, $widget->individualInputAttributes([]));
         $this->assertNotSame($widget, $widget->items([]));
         $this->assertNotSame($widget, $widget->itemsFromValues([]));
         $this->assertNotSame($widget, $widget->value());

--- a/tests/common/Widget/CheckboxListTest.php
+++ b/tests/common/Widget/CheckboxListTest.php
@@ -114,7 +114,7 @@ final class CheckboxListTest extends TestCase
                     1 => 'One',
                     2 => 'Two',
                 ])
-                ->replaceCheckboxAttributes(['class' => 'red'])
+                ->checkboxAttributes(['class' => 'red'])
                 ->withoutContainer()
                 ->render(),
         );
@@ -148,7 +148,7 @@ final class CheckboxListTest extends TestCase
                     2 => 'Two',
                 ])
                 ->readonly()
-                ->replaceCheckboxAttributes(['class' => 'red'])
+                ->checkboxAttributes(['class' => 'red'])
                 ->withoutContainer()
                 ->render(),
         );
@@ -166,7 +166,7 @@ final class CheckboxListTest extends TestCase
                     2 => 'Two',
                     3 => 'Three',
                 ])
-                ->replaceCheckboxAttributes(['class' => 'red'])
+                ->checkboxAttributes(['class' => 'red'])
                 ->addIndividualInputAttributes([
                     2 => ['class' => 'blue'],
                     3 => ['class' => 'green'],
@@ -188,7 +188,7 @@ final class CheckboxListTest extends TestCase
                     2 => 'Two',
                 ])
                 ->uncheckValue(0)
-                ->replaceCheckboxAttributes(['class' => 'red'])
+                ->checkboxAttributes(['class' => 'red'])
                 ->replaceIndividualInputAttributes([
                     0 => ['class' => 'blue'],
                 ])
@@ -209,7 +209,7 @@ final class CheckboxListTest extends TestCase
                     2 => 'Two',
                     3 => 'Three',
                 ])
-                ->replaceCheckboxAttributes(['class' => 'red'])
+                ->checkboxAttributes(['class' => 'red'])
                 ->addIndividualInputAttributes([
                     2 => ['class' => 'blue'],
                     3 => ['class' => 'green'],
@@ -235,7 +235,7 @@ final class CheckboxListTest extends TestCase
                     2 => 'Two',
                     3 => 'Three',
                 ])
-                ->replaceCheckboxAttributes(['class' => 'red'])
+                ->checkboxAttributes(['class' => 'red'])
                 ->addIndividualInputAttributes([
                     2 => ['class' => 'blue'],
                     3 => ['class' => 'green'],
@@ -691,9 +691,8 @@ final class CheckboxListTest extends TestCase
         $this->assertNotSame($widget, $widget->withoutContainer());
         $this->assertNotSame($widget, $widget->containerTag(''));
         $this->assertNotSame($widget, $widget->containerAttributes([]));
-        $this->assertNotSame($widget, $widget->checkboxAttributes([]));
         $this->assertNotSame($widget, $widget->addCheckboxAttributes([]));
-        $this->assertNotSame($widget, $widget->replaceCheckboxAttributes([]));
+        $this->assertNotSame($widget, $widget->checkboxAttributes([]));
         $this->assertNotSame($widget, $widget->individualInputAttributes([]));
         $this->assertNotSame($widget, $widget->addIndividualInputAttributes([]));
         $this->assertNotSame($widget, $widget->replaceIndividualInputAttributes([]));

--- a/tests/common/Widget/RadioListTest.php
+++ b/tests/common/Widget/RadioListTest.php
@@ -164,7 +164,7 @@ final class RadioListTest extends TestCase
                     3 => 'Three',
                 ])
                 ->radioAttributes(['class' => 'red'])
-                ->replaceIndividualInputAttributes([
+                ->individualInputAttributes([
                     2 => ['class' => 'blue'],
                     3 => ['class' => 'green'],
                 ])
@@ -186,7 +186,7 @@ final class RadioListTest extends TestCase
                 ])
                 ->uncheckValue(0)
                 ->radioAttributes(['class' => 'red'])
-                ->replaceIndividualInputAttributes([
+                ->individualInputAttributes([
                     0 => ['class' => 'blue'],
                 ])
                 ->withoutContainer()
@@ -237,7 +237,7 @@ final class RadioListTest extends TestCase
                     2 => ['class' => 'blue'],
                     3 => ['class' => 'green'],
                 ])
-                ->replaceIndividualInputAttributes([
+                ->individualInputAttributes([
                     1 => ['class' => 'yellow'],
                 ])
                 ->withoutContainer()
@@ -654,9 +654,8 @@ final class RadioListTest extends TestCase
         $this->assertNotSame($widget, $widget->containerAttributes([]));
         $this->assertNotSame($widget, $widget->addRadioAttributes([]));
         $this->assertNotSame($widget, $widget->radioAttributes([]));
-        $this->assertNotSame($widget, $widget->individualInputAttributes([]));
         $this->assertNotSame($widget, $widget->addIndividualInputAttributes([]));
-        $this->assertNotSame($widget, $widget->replaceIndividualInputAttributes([]));
+        $this->assertNotSame($widget, $widget->individualInputAttributes([]));
         $this->assertNotSame($widget, $widget->items([]));
         $this->assertNotSame($widget, $widget->itemsFromValues([]));
         $this->assertNotSame($widget, $widget->value(null));

--- a/tests/common/Widget/RadioListTest.php
+++ b/tests/common/Widget/RadioListTest.php
@@ -111,7 +111,7 @@ final class RadioListTest extends TestCase
                     1 => 'One',
                     2 => 'Two',
                 ])
-                ->replaceRadioAttributes(['class' => 'red'])
+                ->radioAttributes(['class' => 'red'])
                 ->withoutContainer()
                 ->render(),
         );
@@ -145,7 +145,7 @@ final class RadioListTest extends TestCase
                     2 => 'Two',
                 ])
                 ->readonly()
-                ->replaceRadioAttributes(['class' => 'red'])
+                ->radioAttributes(['class' => 'red'])
                 ->withoutContainer()
                 ->render(),
         );
@@ -163,7 +163,7 @@ final class RadioListTest extends TestCase
                     2 => 'Two',
                     3 => 'Three',
                 ])
-                ->replaceRadioAttributes(['class' => 'red'])
+                ->radioAttributes(['class' => 'red'])
                 ->replaceIndividualInputAttributes([
                     2 => ['class' => 'blue'],
                     3 => ['class' => 'green'],
@@ -185,7 +185,7 @@ final class RadioListTest extends TestCase
                     2 => 'Two',
                 ])
                 ->uncheckValue(0)
-                ->replaceRadioAttributes(['class' => 'red'])
+                ->radioAttributes(['class' => 'red'])
                 ->replaceIndividualInputAttributes([
                     0 => ['class' => 'blue'],
                 ])
@@ -206,7 +206,7 @@ final class RadioListTest extends TestCase
                     2 => 'Two',
                     3 => 'Three',
                 ])
-                ->replaceRadioAttributes(['class' => 'red'])
+                ->radioAttributes(['class' => 'red'])
                 ->addIndividualInputAttributes([
                     2 => ['class' => 'blue'],
                     3 => ['class' => 'green'],
@@ -232,7 +232,7 @@ final class RadioListTest extends TestCase
                     2 => 'Two',
                     3 => 'Three',
                 ])
-                ->replaceRadioAttributes(['class' => 'red'])
+                ->radioAttributes(['class' => 'red'])
                 ->addIndividualInputAttributes([
                     2 => ['class' => 'blue'],
                     3 => ['class' => 'green'],
@@ -652,9 +652,8 @@ final class RadioListTest extends TestCase
         $this->assertNotSame($widget, $widget->withoutContainer());
         $this->assertNotSame($widget, $widget->containerTag(''));
         $this->assertNotSame($widget, $widget->containerAttributes([]));
-        $this->assertNotSame($widget, $widget->radioAttributes([]));
         $this->assertNotSame($widget, $widget->addRadioAttributes([]));
-        $this->assertNotSame($widget, $widget->replaceRadioAttributes([]));
+        $this->assertNotSame($widget, $widget->radioAttributes([]));
         $this->assertNotSame($widget, $widget->individualInputAttributes([]));
         $this->assertNotSame($widget, $widget->addIndividualInputAttributes([]));
         $this->assertNotSame($widget, $widget->replaceIndividualInputAttributes([]));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #125 

- `Range`: remove `outputAttributes()`, rename `replaceOutputAttributes()` to `outputAttributes()`
- `File`: remove `uncheckInputAttributes()`, rename `replaceUncheckInputAttributes()` to `uncheckInputAttributes()`
- `CheckboxList`: remove `individualInputAttributes()`, rename `replaceIndividualInputAttributes()` to `individualInputAttributes()`
- `CheckboxList`: remove `checkboxAttributes()`, rename `replaceCheckboxAttributes()` to `checkboxAttributes()`
- `RadioList`: remove `individualInputAttributes()`, rename `replaceIndividualInputAttributes()` to `individualInputAttributes()`
- `RadioList`: remove `radioAttributes()`, rename `replaceRadioAttributes()` to `radioAttributes()`
- `ButtonGroup`: remove `buttonAttributes()`, rename `replaceButtonAttributes()` to `buttonAttributes()`
- `Tag`: remove `attributes()`, rename `replaceAttributes()` to `attributes()`
