### PR TITLE
Fix loss keys of named class in `Html::addCssClass()` when class in passed options is string

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
       - 'psalm.xml'
 
   push:
+    branches: [ 'master' ]
     paths-ignore:
       - 'docs/**'
       - 'README.md'

--- a/.github/workflows/composer-require-checker.yml
+++ b/.github/workflows/composer-require-checker.yml
@@ -11,6 +11,7 @@ on:
       - 'psalm.xml'
 
   push:
+    branches: [ 'master' ]
     paths-ignore:
       - 'docs/**'
       - 'README.md'

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -9,6 +9,7 @@ on:
       - 'psalm.xml'
 
   push:
+    branches: [ 'master' ]
     paths-ignore:
       - 'docs/**'
       - 'README.md'

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -14,8 +14,10 @@ name: rector
 jobs:
   rector:
     uses: yiisoft/actions/.github/workflows/rector.yml@master
+    secrets:
+      token: ${{ secrets.YIISOFT_GITHUB_TOKEN }}
     with:
       os: >-
         ['ubuntu-latest']
       php: >-
-        ['8.0']
+        ['8.2']

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -10,6 +10,7 @@ on:
       - 'phpunit.xml.dist'
 
   push:
+    branches: [ 'master' ]
     paths-ignore:
       - 'docs/**'
       - 'README.md'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.1.1 under development
 
-- no changes in this release.
+- Bug #171: Fix loss keys of named class in `Html::addCssClass()` when class in passed options is string (@vjik)
 
 ## 3.1.0 January 17, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.1.1 under development
 
-- Bug #171: Fix loss keys of named class in `Html::addCssClass()` when class in passed options is string (@vjik)
+- Bug #171: Fix loss of keys for named class in `Html::addCssClass()` when class in passed options is a string (@vjik)
 
 ## 3.1.0 January 17, 2023
 

--- a/src/Html.php
+++ b/src/Html.php
@@ -1634,7 +1634,8 @@ final class Html
             } else {
                 /** @psalm-var string $options['class'] */
                 $classes = preg_split('/\s+/', $options['class'], -1, PREG_SPLIT_NO_EMPTY);
-                $options['class'] = implode(' ', self::mergeCssClasses($classes, (array) $class));
+                $classes = self::mergeCssClasses($classes, (array) $class);
+                $options['class'] = is_array($class) ? $classes : implode(' ', $classes);
             }
         } else {
             $options['class'] = $class;
@@ -1680,7 +1681,7 @@ final class Html
      * @param string[] $existingClasses Already existing CSS classes.
      * @param string[] $additionalClasses CSS classes to be added.
      *
-     * @return string[] merge result.
+     * @return string[] The merge result.
      */
     private static function mergeCssClasses(array $existingClasses, array $additionalClasses): array
     {

--- a/tests/common/HtmlTest.php
+++ b/tests/common/HtmlTest.php
@@ -883,12 +883,6 @@ final class HtmlTest extends TestCase
         $this->assertSame(['class' => ['test', 'test2', 'test3']], $options);
 
         $options = [
-            'class' => 'test',
-        ];
-        Html::addCssClass($options, ['test1', 'test2']);
-        $this->assertSame(['class' => 'test test1 test2'], $options);
-
-        $options = [
             'class' => 'test test',
         ];
         Html::addCssClass($options, 'test2');
@@ -909,6 +903,59 @@ final class HtmlTest extends TestCase
         $this->assertSame(['persistent' => 'test1'], $options['class']);
         Html::addCssClass($options, ['additional' => 'test2']);
         $this->assertSame(['persistent' => 'test1', 'additional' => 'test2'], $options['class']);
+    }
+
+    public function testAddCssClassWithKeyToString(): void
+    {
+        $options = ['class' => 'test_class'];
+
+        Html::addCssClass($options, ['widget' => 'some_widget_class']);
+        Html::addCssClass($options, ['widget' => 'some_other_widget_class_2']);
+
+        $this->assertSame(
+            [
+                'class' => [
+                    'test_class',
+                    'widget' => 'some_widget_class',
+                ],
+            ],
+            $options,
+        );
+    }
+
+    public function testAddCssClassWithKeyToArray(): void
+    {
+        $options = ['class' => ['test_class']];
+
+        Html::addCssClass($options, ['widget' => 'some_widget_class']);
+        Html::addCssClass($options, ['widget' => 'some_other_widget_class_2']);
+
+        $this->assertSame(
+            [
+                'class' => [
+                    'test_class',
+                    'widget' => 'some_widget_class',
+                ],
+            ],
+            $options,
+        );
+    }
+
+    public function testAddCssClassWithKeyToKeyArray(): void
+    {
+        $options = ['class' => ['widget' => 'test_class']];
+
+        Html::addCssClass($options, ['widget' => 'some_widget_class']);
+        Html::addCssClass($options, ['widget' => 'some_other_widget_class_2']);
+
+        $this->assertSame(
+            [
+                'class' => [
+                    'widget' => 'test_class',
+                ],
+            ],
+            $options,
+        );
     }
 
     public function testRemoveCssClass(): void

--- a/tests/common/HtmlTest.php
+++ b/tests/common/HtmlTest.php
@@ -905,6 +905,20 @@ final class HtmlTest extends TestCase
         $this->assertSame(['persistent' => 'test1', 'additional' => 'test2'], $options['class']);
     }
 
+    public function testAddCssClassArrayToString(): void
+    {
+        $options = ['class' => 'test'];
+
+        Html::addCssClass($options, ['test1', 'test2']);
+
+        $this->assertSame(
+            [
+                'class' => ['test', 'test1', 'test2'],
+            ],
+            $options,
+        );
+    }
+
     public function testAddCssClassWithKeyToString(): void
     {
         $options = ['class' => 'test_class'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
