### PR TITLE
Allow pass `null` as class to `Html::addCssClass()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bug #171: Fix loss of keys for named class in `Html::addCssClass()` when class in passed options is a string (@vjik)
 - New #174: Add `$attributes` parameter to `Html::ul()` and `Html::ol()` (@AmolKumarGupta)
+- Enh #176: Allow pass `null` as class to `Html::addCssClass()`, nulled classes will be ignored (@vjik)
 
 ## 3.1.0 January 17, 2023
 

--- a/src/Html.php
+++ b/src/Html.php
@@ -1635,7 +1635,7 @@ final class Html
      * @see removeCssClass()
      *
      * @param array $options The options to be modified.
-     * @param string|null|string[]|null[] $class The CSS class(es) to be added. Null values will be ignored.
+     * @param null[]|string|string[]|null $class The CSS class(es) to be added. Null values will be ignored.
      *
      * @psalm-param string|array<array-key,string|null> $class
      */
@@ -1697,7 +1697,7 @@ final class Html
      * This method provides the priority for named existing classes over additional.
      *
      * @param string[] $existingClasses Already existing CSS classes.
-     * @param string[]|null[] $additionalClasses CSS classes to be added.
+     * @param null[]|string[] $additionalClasses CSS classes to be added.
      *
      * @return string[] The merge result.
      *

--- a/src/Html.php
+++ b/src/Html.php
@@ -1635,10 +1635,16 @@ final class Html
      * @see removeCssClass()
      *
      * @param array $options The options to be modified.
-     * @param string|string[] $class The CSS class(es) to be added.
+     * @param string|null|string[]|null[] $class The CSS class(es) to be added. Null values will be ignored.
+     *
+     * @psalm-param string|array<array-key,string|null> $class
      */
-    public static function addCssClass(array &$options, string|array $class): void
+    public static function addCssClass(array &$options, string|array|null $class): void
     {
+        if ($class === null) {
+            return;
+        }
+
         if (isset($options['class'])) {
             if (is_array($options['class'])) {
                 /** @psalm-var string[] $options['class'] */
@@ -1691,13 +1697,18 @@ final class Html
      * This method provides the priority for named existing classes over additional.
      *
      * @param string[] $existingClasses Already existing CSS classes.
-     * @param string[] $additionalClasses CSS classes to be added.
+     * @param string[]|null[] $additionalClasses CSS classes to be added.
      *
      * @return string[] The merge result.
+     *
+     * @psalm-param array<array-key,string|null> $additionalClasses
      */
     private static function mergeCssClasses(array $existingClasses, array $additionalClasses): array
     {
         foreach ($additionalClasses as $key => $class) {
+            if ($class === null) {
+                continue;
+            }
             if (is_int($key) && !in_array($class, $existingClasses, true)) {
                 $existingClasses[] = $class;
             } elseif (!isset($existingClasses[$key])) {

--- a/tests/common/HtmlTest.php
+++ b/tests/common/HtmlTest.php
@@ -868,39 +868,33 @@ final class HtmlTest extends TestCase
         $this->assertSame($expected, Html::renderTagAttributes($attributes));
     }
 
-    public function testAddCssClass(): void
+    public function dataAddCssClass(): array
     {
-        $options = [];
-        Html::addCssClass($options, 'test');
-        $this->assertSame(['class' => 'test'], $options);
-        Html::addCssClass($options, 'test');
-        $this->assertSame(['class' => 'test'], $options);
-        Html::addCssClass($options, 'test2');
-        $this->assertSame(['class' => 'test test2'], $options);
-        Html::addCssClass($options, 'test');
-        $this->assertSame(['class' => 'test test2'], $options);
-        Html::addCssClass($options, 'test2');
-        $this->assertSame(['class' => 'test test2'], $options);
-        Html::addCssClass($options, 'test3');
-        $this->assertSame(['class' => 'test test2 test3'], $options);
-        Html::addCssClass($options, 'test2');
-        $this->assertSame(['class' => 'test test2 test3'], $options);
-
-        $options = [
-            'class' => ['test'],
+        return [
+            0 => [['class' => 'test'], [], 'test'],
+            1 => [['class' => 'test'], ['class' => 'test'], 'test'],
+            2 => [['class' => 'test test2'], ['class' => 'test'], 'test2'],
+            3 => [['class' => 'test test2'], ['class' => 'test test2'], 'test'],
+            4 => [['class' => 'test test2'], ['class' => 'test test2'], 'test2'],
+            5 => [['class' => 'test test2 test3'], ['class' => 'test test2'], 'test3'],
+            6 => [['class' => 'test test2 test3'], ['class' => 'test test2 test3'], 'test2'],
+            7 => [['class' => ['test', 'test2']], ['class' => ['test']], 'test2'],
+            8 => [['class' => ['test', 'test2']], ['class' => ['test', 'test2']], 'test2'],
+            9 => [['class' => ['test', 'test2', 'test3']], ['class' => ['test', 'test2']], ['test3']],
+            10 => [['class' => 'test test2'], ['class' => 'test test'], 'test2'],
+            11 => [['class' => 'test test2'], ['class' => 'test test2'], null],
+            12 => [['class' => ['test', 'test2']], ['class' => 'test test2'], [null]],
+            13 => [['class' => ['t1', 't2', 't3', 't4']], ['class' => 't1 t2'], ['t3', null, 't4']],
         ];
-        Html::addCssClass($options, 'test2');
-        $this->assertSame(['class' => ['test', 'test2']], $options);
-        Html::addCssClass($options, 'test2');
-        $this->assertSame(['class' => ['test', 'test2']], $options);
-        Html::addCssClass($options, ['test3']);
-        $this->assertSame(['class' => ['test', 'test2', 'test3']], $options);
+    }
 
-        $options = [
-            'class' => 'test test',
-        ];
-        Html::addCssClass($options, 'test2');
-        $this->assertSame(['class' => 'test test2'], $options);
+    /**
+     * @dataProvider dataAddCssClass
+     */
+    public function testAddCssClass(array $expected, array $options, array|string|null $class): void
+    {
+        Html::addCssClass($options, $class);
+        $this->assertSame($expected, $options);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -
