### PR TITLE
Replace constant `PHP_EOL` to `"\n"`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.2.1 under development
 
 - New #173: Add class for tag 'html' and method `Html::html()` (@dood-)
+- Chg #179: Replace constant `PHP_EOL` to `"\n"` (@vjik) 
 
 ## 3.2.0 November 21, 2023
 

--- a/src/Tag/Form.php
+++ b/src/Tag/Form.php
@@ -172,7 +172,7 @@ final class Form extends NormalTag
     protected function prepend(): string
     {
         return $this->csrfToken !== null
-            ? PHP_EOL . Input::hidden($this->csrfName, $this->csrfToken)
+            ? "\n" . Input::hidden($this->csrfName, $this->csrfToken)
             : '';
     }
 

--- a/tests/common/Tag/FormTest.php
+++ b/tests/common/Tag/FormTest.php
@@ -77,13 +77,13 @@ final class FormTest extends TestCase
         $tag = Form::tag()->csrf('abc', 'csrf-token');
 
         $this->assertSame(
-            '<form>' . PHP_EOL .
+            '<form>' . "\n" .
             '<input type="hidden" name="csrf-token" value="abc">',
             $tag->open()
         );
 
         $this->assertSame(
-            '<form>' . PHP_EOL .
+            '<form>' . "\n" .
             '<input type="hidden" name="csrf-token" value="abc"></form>',
             $tag->render()
         );
@@ -92,7 +92,7 @@ final class FormTest extends TestCase
     public function testCsrfDefaultName(): void
     {
         $this->assertSame(
-            '<form>' . PHP_EOL .
+            '<form>' . "\n" .
             '<input type="hidden" name="_csrf" value="abc"></form>',
             Form::tag()
                 ->csrf('abc')
@@ -103,7 +103,7 @@ final class FormTest extends TestCase
     public function testStringableCsrfToken(): void
     {
         $this->assertSame(
-            '<form>' . PHP_EOL .
+            '<form>' . "\n" .
             '<input type="hidden" name="_csrf" value="abc"></form>',
             Form::tag()
                 ->csrf(new StringableObject('abc'))


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #178 