### PR TITLE
Add `\n` after hidden input in checkbox and radio HTML code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.3.1 under development
 
-- no changes in this release.
+- Enh #181: Add `\n` after hidden input in checkbox and radio HTML code (@vjik)
 
 ## 3.3.0 December 01, 2023
 

--- a/src/Tag/Base/BooleanInputTag.php
+++ b/src/Tag/Base/BooleanInputTag.php
@@ -116,7 +116,7 @@ abstract class BooleanInputTag extends InputTag
             $input = $input->attribute('form', $this->attributes['form']);
         }
 
-        return $input->render();
+        return $input->render() . "\n";
     }
 
     private function renderLabelOpenTag(array $attributes): string

--- a/tests/common/Tag/Base/BooleanInputTagTest.php
+++ b/tests/common/Tag/Base/BooleanInputTagTest.php
@@ -154,12 +154,18 @@ final class BooleanInputTagTest extends TestCase
             ['<input type="test" name="color">', 'color', null],
             ['<input type="test" name="color[]">', 'color[]', null],
             [
-                '<input type="hidden" name="color" value="7"><input type="test" name="color">',
+                <<<HTML
+                <input type="hidden" name="color" value="7">
+                <input type="test" name="color">
+                HTML,
                 'color',
                 7,
             ],
             [
-                '<input type="hidden" name="color" value="7"><input type="test" name="color[]">',
+                <<<HTML
+                <input type="hidden" name="color" value="7">
+                <input type="test" name="color[]">
+                HTML,
                 'color[]',
                 7,
             ],
@@ -185,8 +191,10 @@ final class BooleanInputTagTest extends TestCase
     public function testUncheckValueDisabled(): void
     {
         $this->assertSame(
-            '<input type="hidden" name="color" value="7" disabled>' .
-            '<input type="test" name="color" disabled>',
+            <<<HTML
+            <input type="hidden" name="color" value="7" disabled>
+            <input type="test" name="color" disabled>
+            HTML,
             TestBooleanInputTag::tag()
                 ->name('color')
                 ->uncheckValue(7)
@@ -198,8 +206,10 @@ final class BooleanInputTagTest extends TestCase
     public function testUncheckValueForm(): void
     {
         $this->assertSame(
-            '<input type="hidden" name="color" value="7" form="post">' .
-            '<input type="test" name="color" form="post">',
+            <<<HTML
+            <input type="hidden" name="color" value="7" form="post">
+            <input type="test" name="color" form="post">
+            HTML,
             TestBooleanInputTag::tag()
                 ->name('color')
                 ->uncheckValue(7)
@@ -211,8 +221,10 @@ final class BooleanInputTagTest extends TestCase
     public function testUncheckValueWithLabel(): void
     {
         $this->assertSame(
-            '<input type="hidden" name="color" value="7">' .
-            '<label><input type="test" name="color"> Seven</label>',
+            <<<HTML
+            <input type="hidden" name="color" value="7">
+            <label><input type="test" name="color"> Seven</label>
+            HTML,
             TestBooleanInputTag::tag()
                 ->name('color')
                 ->uncheckValue(7)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
