### PR TITLE
Fix #208

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -979,6 +979,7 @@ final class Html
     {
         $tag = Div::tag();
         if (!empty($attributes)) {
+            $attributes = self::filterNullAttributes($attributes);
             $tag = $tag->attributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
@@ -1962,5 +1963,27 @@ final class Html
         }
 
         return ' ' . $name . '=' . $quote . $encodedValue . $quote;
+    }
+
+    /**
+     * Removes array elements that are null or contain subarrays that contain null
+     * 
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    private static function filterNullAttributes(array $attributes): array
+    {
+        return array_filter($attributes, function ($attribute) {
+            if (!isset($attribute)) return false;
+            if (is_array($attribute)) {
+                $containsNull = false;
+                array_walk_recursive($attribute, function ($attribute) use (&$containsNull) {
+                    if (!isset($attribute)) {
+                        $containsNull = true;
+                    }
+                });
+                return !$containsNull;
+            }
+            return true;
+        });
     }
 }

--- a/tests/common/HtmlTest.php
+++ b/tests/common/HtmlTest.php
@@ -549,6 +549,12 @@ final class HtmlTest extends TestCase
     public function testDiv(): void
     {
         $this->assertSame('<div></div>', Html::div()->render());
+        $this->assertSame('<div></div>', Html::div(attributes: [
+            'data-test1' => null,
+            'data' => [
+                'test2' => null
+            ]
+        ])->render());
         $this->assertSame('<div>hello</div>', Html::div('hello')->render());
         $this->assertSame('<div id="main">hello</div>', Html::div('hello', ['id' => 'main'])->render());
         $this->assertSame('<div><span>Hello</span></div>', Html::div(Html::span('Hello'))->render());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | This change fixes #208 by filtering elements from the attribute array that contain null values.
