### PR TITLE
Fix documented method call

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ use Yiisoft\Html\Tag\Meta;
     <?= Html::openTag('div', ['class' => 'container flex-fill']) ?>
         <?= Html::p('', ['class' => 'float-left']) ?>
         <?= Html::p()
-            ->replaceClass('float-right')
+            ->class('float-right')
             ->content(
                 'Powered by ',
                 Html::a(
@@ -94,7 +94,7 @@ echo \Yiisoft\Html\Tag\Div::tag()
     )
     ->encode(false)
     ->id('ContactEmail')
-    ->replaceClass('red');
+    ->class('red');
 ```
 
 ... will generate the following HTML:


### PR DESCRIPTION
`Tag::replaceClass()` renamed to `Tag::class()` in commit: c08ec25f5b644cfb602578819f534266eb24bbd3

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
