### PR TITLE
Add `Stringable` and array values support to textarea tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.5.1 under development
 
 - Bug #208: Fix output of `null` value attributes in `Html::renderTagAttributes()` (@es-sayers)
+- Enh #214: Add `Stringable` and array values support to textarea tag (@vjik) 
 
 ## 3.5.0 July 11, 2024
 

--- a/src/Html.php
+++ b/src/Html.php
@@ -892,10 +892,10 @@ final class Html
      * Generates a {@see Textarea} input.
      *
      * @param string|null $name The input name.
-     * @param string|null $value The input value.
+     * @param string|Stringable|string[]|null $value The input value.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function textarea(?string $name = null, ?string $value = null, array $attributes = []): Textarea
+    public static function textarea(?string $name = null, string|Stringable|array|null $value = null, array $attributes = []): Textarea
     {
         $tag = Textarea::tag();
         if ($name !== null) {

--- a/src/Tag/Textarea.php
+++ b/src/Tag/Textarea.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace Yiisoft\Html\Tag;
 
+use Stringable;
 use Yiisoft\Html\Tag\Base\NormalTag;
 use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+use function implode;
+use function is_array;
+use function is_string;
 
 /**
  * @link https://www.w3.org/TR/html52/sec-forms.html#the-textarea-element
@@ -35,9 +40,15 @@ final class Textarea extends NormalTag
         return $new;
     }
 
-    public function value(?string $value): self
+    /**
+     * @param string|Stringable|string[]|null $value
+     */
+    public function value(string|Stringable|array|null $value): self
     {
-        return $this->content($value ?? '');
+        $content = is_array($value)
+            ? implode("\n", $value)
+            : (string) $value;
+        return $this->content($content);
     }
 
     /**

--- a/tests/common/Tag/TextareaTest.php
+++ b/tests/common/Tag/TextareaTest.php
@@ -6,6 +6,7 @@ namespace Yiisoft\Html\Tests\Tag;
 
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Html\Tag\Textarea;
+use Yiisoft\Html\Tests\Objects\StringableObject;
 
 final class TextareaTest extends TestCase
 {
@@ -71,14 +72,28 @@ final class TextareaTest extends TestCase
     {
         return [
             ['<textarea></textarea>', null],
+            ['<textarea></textarea>', ''],
+            ['<textarea></textarea>', new StringableObject('')],
             ['<textarea>content</textarea>', 'content'],
+            ['<textarea>content</textarea>', new StringableObject('content')],
+            [
+                <<<HTML
+                <textarea>a
+                b
+
+                c
+
+                d</textarea>
+                HTML,
+                ['a', 'b', null, 'c', '', 'd']
+            ],
         ];
     }
 
     /**
      * @dataProvider dataValue
      */
-    public function testValue(string $expected, ?string $value): void
+    public function testValue(string $expected, mixed $value): void
     {
         $this->assertSame($expected, (string)Textarea::tag()->value($value));
     }

--- a/tests/common/Tag/TextareaTest.php
+++ b/tests/common/Tag/TextareaTest.php
@@ -85,7 +85,7 @@ final class TextareaTest extends TestCase
 
                 d</textarea>
                 HTML,
-                ['a', new StringableObject('b'), null, 'c', '', 'd']
+                ['a', new StringableObject('b'), null, 'c', '', 'd'],
             ],
         ];
     }

--- a/tests/common/Tag/TextareaTest.php
+++ b/tests/common/Tag/TextareaTest.php
@@ -85,7 +85,7 @@ final class TextareaTest extends TestCase
 
                 d</textarea>
                 HTML,
-                ['a', 'b', null, 'c', '', 'd']
+                ['a', new StringableObject('b'), null, 'c', '', 'd']
             ],
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
