### PR TITLE
Enhance `addClass()` and `class()` methods to support `BackedEnum` for CSS classes.

### DIFF
--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -30,4 +30,4 @@ jobs:
       os: >-
         ['ubuntu-latest']
       php: >-
-        ['8.1']
+        ['8.3']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 3.8.1 under development
 
-- Enh #230: Add support `BackedEnum` value to `Html::addCssClass()`, `Tag::addClass()` and `Tag::class()` methods (@terabytesoftw)
+- Enh #230: Add backed enumeration value support to `Html::addCssClass()`, `Tag::addClass()` and `Tag::class()`
+  methods (@terabytesoftw)
 
 ## 3.8.0 October 29, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.8.1 under development
 
-- Enh #230: Add support `BackedEnum` value to `Html::addCssClass()` (@terabytesoftw)
+- Enh #230: Add support `BackedEnum` value to `Html::addCssClass()`, `Tag::addClass()` and `Tag::class()` methods (@terabytesoftw)
 
 ## 3.8.0 October 29, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.8.1 under development
 
-- no changes in this release.
+- Enh #230: Add support `BackedEnum` value to `Html::addCssClass()` (@terabytesoftw)
 
 ## 3.8.0 October 29, 2024
 

--- a/src/Html.php
+++ b/src/Html.php
@@ -1703,7 +1703,10 @@ final class Html
         }
 
         if ($class instanceof BackedEnum) {
-            $class = is_string($class->value) ? $class->value : null;
+            if (is_int($class->value)) {
+                return;
+            }
+            $class = $class->value;
         }
 
         if (is_array($class)) {

--- a/src/Html.php
+++ b/src/Html.php
@@ -1694,7 +1694,7 @@ final class Html
      * @param BackedEnum|BackedEnum[]|null[]|string|string[]|null $class The CSS class(es) to be added. Null values will
      * be ignored.
      *
-     * @psalm-param BackedEnum|string|array<array-key,BackedEnum|string|null> $class
+     * @psalm-param BackedEnum|string|array<array-key,BackedEnum|string|null>|null $class
      */
     public static function addCssClass(array &$options, BackedEnum|array|string|null $class): void
     {

--- a/src/Html.php
+++ b/src/Html.php
@@ -1691,9 +1691,10 @@ final class Html
      * @see removeCssClass()
      *
      * @param array $options The options to be modified.
-     * @param BackedEnum|null[]|string|string[]|null $class The CSS class(es) to be added. Null values will be ignored.
+     * @param BackedEnum|BackedEnum[]|null[]|string|string[]|null $class The CSS class(es) to be added. Null values will
+     * be ignored.
      *
-     * @psalm-param string|array<array-key,string|null> $class
+     * @psalm-param BackedEnum|string|array<array-key,BackedEnum|string|null> $class
      */
     public static function addCssClass(array &$options, BackedEnum|array|string|null $class): void
     {

--- a/src/Html.php
+++ b/src/Html.php
@@ -1707,22 +1707,20 @@ final class Html
         }
 
         if (is_array($class)) {
-            $class = array_map(
-                static function ($item) {
-                    if ($item instanceof BackedEnum) {
-                        return is_string($item->value) ? $item->value : null;
-                    }
+            $filteredClass = [];
+            foreach ($class as $key => $value) {
+                if ($value instanceof BackedEnum) {
+                    $value = is_string($value->value) ? $value->value : null;
+                }
 
-                    return $item;
-                },
-                $class
-            );
-
-            $class = array_filter($class, static fn (mixed $c): bool => $c !== null);
-
-            if (empty($class)) {
+                if ($value !== null) {
+                    $filteredClass[$key] = $value;
+                }
+            }
+            if (empty($filteredClass)) {
                 return;
             }
+            $class = $filteredClass;
         }
 
         if (isset($options['class'])) {

--- a/src/Html.php
+++ b/src/Html.php
@@ -84,6 +84,7 @@ use function in_array;
 use function is_array;
 use function is_bool;
 use function is_int;
+use function is_string;
 use function strlen;
 
 /**
@@ -1713,7 +1714,7 @@ final class Html
             $filteredClass = [];
             foreach ($class as $key => $value) {
                 if ($value instanceof BackedEnum) {
-                    $value = \is_string($value->value) ? $value->value : null;
+                    $value = is_string($value->value) ? $value->value : null;
                 }
 
                 if ($value !== null) {

--- a/src/Html.php
+++ b/src/Html.php
@@ -1713,7 +1713,7 @@ final class Html
             $filteredClass = [];
             foreach ($class as $key => $value) {
                 if ($value instanceof BackedEnum) {
-                    $value = is_string($value->value) ? $value->value : null;
+                    $value = \is_string($value->value) ? $value->value : null;
                 }
 
                 if ($value !== null) {

--- a/src/Html.php
+++ b/src/Html.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Html;
 
+use BackedEnum;
 use InvalidArgumentException;
 use JsonException;
 use Stringable;
@@ -1690,17 +1691,34 @@ final class Html
      * @see removeCssClass()
      *
      * @param array $options The options to be modified.
-     * @param null[]|string|string[]|null $class The CSS class(es) to be added. Null values will be ignored.
+     * @param BackedEnum|null[]|string|string[]|null $class The CSS class(es) to be added. Null values will be ignored.
      *
      * @psalm-param string|array<array-key,string|null> $class
      */
-    public static function addCssClass(array &$options, string|array|null $class): void
+    public static function addCssClass(array &$options, BackedEnum|array|string|null $class): void
     {
         if ($class === null) {
             return;
         }
+
+        if ($class instanceof BackedEnum) {
+            $class = is_string($class->value) ? $class->value : null;
+        }
+
         if (is_array($class)) {
+            $class = array_map(
+                static function ($item) {
+                    if ($item instanceof BackedEnum) {
+                        return is_string($item->value) ? $item->value : null;
+                    }
+
+                    return $item;
+                },
+                $class
+            );
+
             $class = array_filter($class, static fn (mixed $c): bool => $c !== null);
+
             if (empty($class)) {
                 return;
             }

--- a/src/Tag/Base/Tag.php
+++ b/src/Tag/Base/Tag.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Html\Tag\Base;
 
+use BackedEnum;
 use Yiisoft\Html\Html;
 use Yiisoft\Html\NoEncodeStringableInterface;
 
@@ -81,27 +82,35 @@ abstract class Tag implements NoEncodeStringableInterface
     /**
      * Add one or more CSS classes to the tag.
      *
-     * @param string|null ...$class One or many CSS classes.
+     * @param BackedEnum|string|null ...$class One or many CSS classes.
      */
-    final public function addClass(?string ...$class): static
+    final public function addClass(BackedEnum|string|null ...$class): static
     {
         $new = clone $this;
-        Html::addCssClass(
-            $new->attributes,
-            array_filter($class, static fn ($c) => $c !== null),
-        );
+        foreach ($class as $c) {
+            if ($c !== null) {
+                Html::addCssClass($new->attributes, $c instanceof BackedEnum ? $c->value : $c);
+            }
+        }
         return $new;
     }
 
     /**
      * Replace current tag CSS classes with a new set of classes.
      *
-     * @param string|null ...$class One or many CSS classes.
+     * @param BackedEnum|string|null ...$class One or many CSS classes.
      */
-    final public function class(?string ...$class): static
+    final public function class(BackedEnum|string|null ...$class): static
     {
         $new = clone $this;
-        $new->attributes['class'] = array_filter($class, static fn ($c) => $c !== null);
+        $processClass = [];
+        foreach ($class as $c) {
+            if ($c !== null) {
+                $processClass[] = $c instanceof BackedEnum ? $c->value : $c;
+            }
+        }
+        unset($new->attributes['class']);
+        Html::addCssClass($new->attributes, $processClass);
         return $new;
     }
 

--- a/src/Tag/Base/Tag.php
+++ b/src/Tag/Base/Tag.php
@@ -89,7 +89,10 @@ abstract class Tag implements NoEncodeStringableInterface
         $new = clone $this;
         foreach ($class as $c) {
             if ($c !== null) {
-                Html::addCssClass($new->attributes, $c instanceof BackedEnum ? $c->value : $c);
+                if ($c instanceof BackedEnum) {
+                    $c = is_string($c->value) ? $c->value : null;
+                }
+                Html::addCssClass($new->attributes, $c);
             }
         }
         return $new;
@@ -106,7 +109,10 @@ abstract class Tag implements NoEncodeStringableInterface
         $processClass = [];
         foreach ($class as $c) {
             if ($c !== null) {
-                $processClass[] = $c instanceof BackedEnum ? $c->value : $c;
+                if ($c instanceof BackedEnum) {
+                    $c = is_string($c->value) ? $c->value : null;
+                }
+                $processClass[] = $c;
             }
         }
         unset($new->attributes['class']);

--- a/src/Tag/Base/Tag.php
+++ b/src/Tag/Base/Tag.php
@@ -87,14 +87,7 @@ abstract class Tag implements NoEncodeStringableInterface
     final public function addClass(BackedEnum|string|null ...$class): static
     {
         $new = clone $this;
-        foreach ($class as $c) {
-            if ($c !== null) {
-                if ($c instanceof BackedEnum) {
-                    $c = is_string($c->value) ? $c->value : null;
-                }
-                Html::addCssClass($new->attributes, $c);
-            }
-        }
+        Html::addCssClass($new->attributes, $class);
         return $new;
     }
 
@@ -106,17 +99,8 @@ abstract class Tag implements NoEncodeStringableInterface
     final public function class(BackedEnum|string|null ...$class): static
     {
         $new = clone $this;
-        $processClass = [];
-        foreach ($class as $c) {
-            if ($c !== null) {
-                if ($c instanceof BackedEnum) {
-                    $c = is_string($c->value) ? $c->value : null;
-                }
-                $processClass[] = $c;
-            }
-        }
         unset($new->attributes['class']);
-        Html::addCssClass($new->attributes, $processClass);
+        Html::addCssClass($new->attributes, $class);
         return $new;
     }
 

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -10,6 +10,8 @@ use PHPUnit\Framework\TestCase;
 use Yiisoft\Html\Html;
 use Yiisoft\Html\Tag\Div;
 use Yiisoft\Html\Tests\Objects\StringableObject;
+use Yiisoft\Html\Tests\Support\ClassEnum;
+use Yiisoft\Html\Tests\Support\IntegerEnum;
 
 use function array_key_exists;
 
@@ -966,6 +968,22 @@ final class HtmlTest extends TestCase
     {
         Html::addCssClass($options, $class);
         $this->assertSame($expected, $options);
+    }
+
+    public function testAddCssClassWithBackedEnum(): void
+    {
+        $options = ['class' => 'test'];
+        Html::addCssClass($options, ClassEnum::TEST_CLASS_2);
+        $this->assertSame(['class' => 'test test-class-2'], $options);
+
+        Html::addCssClass($options, IntegerEnum::A);
+        $this->assertSame(['class' => 'test test-class-2'], $options);
+
+        Html::addCssClass($options, ClassEnum::TEST_CLASS_1);
+        $this->assertSame(['class' => 'test test-class-2 test-class-1'], $options);
+
+        Html::addCssClass($options, IntegerEnum::B);
+        $this->assertSame(['class' => 'test test-class-2 test-class-1'], $options);
     }
 
     /**

--- a/tests/Support/ClassEnum.php
+++ b/tests/Support/ClassEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Support;
+
+enum ClassEnum: string
+{
+    case TEST_CLASS_1 = 'test-class-1';
+    case TEST_CLASS_2 = 'test-class-2';
+}

--- a/tests/Tag/Base/TagTest.php
+++ b/tests/Tag/Base/TagTest.php
@@ -175,7 +175,7 @@ final class TagTest extends TestCase
             ['<test class="main">', ['main']],
             ['<test class="main bold">', ['main bold']],
             ['<test class="main bold">', ['main', 'bold']],
-            ['<test class="test-class-1 test-class-2">', [ClassEnum::TEST_CLASS_1, ClassEnum::TEST_CLASS_2]]
+            ['<test class="test-class-1 test-class-2">', [ClassEnum::TEST_CLASS_1, ClassEnum::TEST_CLASS_2]],
         ];
     }
 

--- a/tests/Tag/Base/TagTest.php
+++ b/tests/Tag/Base/TagTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Html\Tests\Objects\TestTag;
 use Yiisoft\Html\Tests\Support\ClassEnum;
+use Yiisoft\Html\Tests\Support\IntegerEnum;
 
 final class TagTest extends TestCase
 {
@@ -140,6 +141,10 @@ final class TagTest extends TestCase
             ['<test class="main italic bold">', ['italic bold']],
             ['<test class="main italic bold">', ['italic', 'bold']],
             ['<test class="main test-class-1 test-class-2">', [ClassEnum::TEST_CLASS_1, ClassEnum::TEST_CLASS_2]],
+            [
+                '<test class="main test-class-1 test-class-2">',
+                [IntegerEnum::A, ClassEnum::TEST_CLASS_1, IntegerEnum::B, ClassEnum::TEST_CLASS_2],
+            ],
         ];
     }
 
@@ -176,6 +181,10 @@ final class TagTest extends TestCase
             ['<test class="main bold">', ['main bold']],
             ['<test class="main bold">', ['main', 'bold']],
             ['<test class="test-class-1 test-class-2">', [ClassEnum::TEST_CLASS_1, ClassEnum::TEST_CLASS_2]],
+            [
+                '<test class="test-class-1 test-class-2">',
+                [IntegerEnum::A, ClassEnum::TEST_CLASS_1, IntegerEnum::B, ClassEnum::TEST_CLASS_2],
+            ],
         ];
     }
 

--- a/tests/Tag/Base/TagTest.php
+++ b/tests/Tag/Base/TagTest.php
@@ -7,6 +7,7 @@ namespace Yiisoft\Html\Tests\Tag\Base;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Html\Tests\Objects\TestTag;
+use Yiisoft\Html\Tests\Support\ClassEnum;
 
 final class TagTest extends TestCase
 {
@@ -138,6 +139,7 @@ final class TagTest extends TestCase
             ['<test class="main bold">', ['bold']],
             ['<test class="main italic bold">', ['italic bold']],
             ['<test class="main italic bold">', ['italic', 'bold']],
+            ['<test class="main test-class-1 test-class-2">', [ClassEnum::TEST_CLASS_1, ClassEnum::TEST_CLASS_2]],
         ];
     }
 
@@ -173,6 +175,7 @@ final class TagTest extends TestCase
             ['<test class="main">', ['main']],
             ['<test class="main bold">', ['main bold']],
             ['<test class="main bold">', ['main', 'bold']],
+            ['<test class="test-class-1 test-class-2">', [ClassEnum::TEST_CLASS_1, ClassEnum::TEST_CLASS_2]]
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

