### PR TITLE
Fix #223: Make `$content` optional in `Button` factories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.9.1 under development
 
 - Bug #232: Render `loading` attribute before `src` (@samdark)
-- Chg #223: Make `content` optional parameter (@FrankiFixx)
+- Enh #223: Make `$content` parameter optional in `Button` factories (@FrankiFixx)
 
 ## 3.9.0 November 29, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.9.1 under development
 
 - Bug #232: Render `loading` attribute before `src` (@samdark)
+- New #223: Make `content` optional parameter (@FrankiFixx)
 
 ## 3.9.0 November 29, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.9.1 under development
 
 - Bug #232: Render `loading` attribute before `src` (@samdark)
-- New #223: Make `content` optional parameter (@FrankiFixx)
+- Chg #223: Make `content` optional parameter (@FrankiFixx)
 
 ## 3.9.0 November 29, 2024
 

--- a/src/Tag/Button.php
+++ b/src/Tag/Button.php
@@ -14,21 +14,21 @@ final class Button extends NormalTag
 {
     use TagContentTrait;
 
-    public static function button(string $content): self
+    public static function button(string $content = ''): self
     {
         $button = self::tag()->content($content);
         $button->attributes['type'] = 'button';
         return $button;
     }
 
-    public static function submit(string $content): self
+    public static function submit(string $content = ''): self
     {
         $button = self::tag()->content($content);
         $button->attributes['type'] = 'submit';
         return $button;
     }
 
-    public static function reset(string $content): self
+    public static function reset(string $content = ''): self
     {
         $button = self::tag()->content($content);
         $button->attributes['type'] = 'reset';

--- a/tests/Tag/ButtonTest.php
+++ b/tests/Tag/ButtonTest.php
@@ -28,6 +28,30 @@ final class ButtonTest extends TestCase
         );
     }
 
+    public function testButtonWithoutContent(): void
+    {
+        $this->assertSame(
+            '<button type="button"></button>',
+            (string)Button::button()
+        );
+    }
+
+    public function testSubmitWithoutContent(): void
+    {
+        $this->assertSame(
+            '<button type="button"></button>',
+            (string)Button::submit()
+        );
+    }
+
+    public function testResetWithoutContent(): void
+    {
+        $this->assertSame(
+            '<button type="button"></button>',
+            (string)Button::reset()
+        );
+    }
+
     public function testSubmit(): void
     {
         $this->assertSame(

--- a/tests/Tag/ButtonTest.php
+++ b/tests/Tag/ButtonTest.php
@@ -39,7 +39,7 @@ final class ButtonTest extends TestCase
     public function testSubmitWithoutContent(): void
     {
         $this->assertSame(
-            '<button type="button"></button>',
+            '<button type="submit"></button>',
             (string)Button::submit()
         );
     }
@@ -47,7 +47,7 @@ final class ButtonTest extends TestCase
     public function testResetWithoutContent(): void
     {
         $this->assertSame(
-            '<button type="button"></button>',
+            '<button type="reset"></button>',
             (string)Button::reset()
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️/
| Breaks BC?    | ❌
| Fixed issues  | Fix #223
