### PR TITLE
Allow to pass `null` to `Select::value()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Enh #223: Make `$content` parameter optional in `Button` factories (@FrankiFixx)
 - Chg #240, #242: Change PHP constraint in `composer.json` to `8.1 - 8.4` (@vjik)
 - Bug #242: Fix the nullable parameter declarations for compatibility with PHP 8.4 (@vjik)
+- Enh #244: Allow to pass `null` to `Select::value()` method (@vjik)
 
 ## 3.9.0 November 29, 2024
 

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "phpunit/phpunit": "^10.5.45",
         "rector/rector": "^2.0.8",
         "spatie/phpunit-watcher": "^1.24",
-        "vimeo/psalm": "^5.26.1 || ^6.8.8"
+        "vimeo/psalm": "^5.26.1 || ^6.10.0"
     },
     "autoload": {
         "psr-4": {
@@ -50,7 +50,6 @@
     },
     "config": {
         "sort-packages": true,
-        "bump-after-update": "dev",
         "allow-plugins": {
             "infection/extension-installer": true,
             "composer/package-versions-deprecated": true

--- a/src/Tag/Select.php
+++ b/src/Tag/Select.php
@@ -48,7 +48,7 @@ final class Select extends NormalTag
      */
     public function value(Stringable|bool|float|int|string|BackedEnum|null ...$value): self
     {
-        $values =  array_filter(
+        $values = array_filter(
             $value,
             static fn (mixed $v): bool => $v !== null,
         );

--- a/src/Tag/Select.php
+++ b/src/Tag/Select.php
@@ -27,7 +27,7 @@ final class Select extends NormalTag
     private ?string $unselectValue = null;
 
     /**
-     * @psalm-var list<string>
+     * @var string[]
      */
     private array $values = [];
 
@@ -52,7 +52,6 @@ final class Select extends NormalTag
             $value,
             static fn (mixed $v): bool => $v !== null,
         );
-        $values = array_values($values);
         $values = array_map(
             static function (Stringable|bool|float|int|string|BackedEnum $v): string {
                 return (string) ($v instanceof BackedEnum ? $v->value : $v);

--- a/src/Tag/Select.php
+++ b/src/Tag/Select.php
@@ -44,17 +44,24 @@ final class Select extends NormalTag
     }
 
     /**
-     * @psalm-param Stringable|scalar|BackedEnum ...$value One or more string values.
+     * @psalm-param Stringable|scalar|BackedEnum|null ...$value One or more string values.
      */
-    public function value(Stringable|bool|float|int|string|BackedEnum ...$value): self
+    public function value(Stringable|bool|float|int|string|BackedEnum|null ...$value): self
     {
-        $new = clone $this;
-        $new->values = array_map(
+        $values =  array_filter(
+            $value,
+            static fn (mixed $v): bool => $v !== null,
+        );
+        $values = array_values($values);
+        $values = array_map(
             static function (Stringable|bool|float|int|string|BackedEnum $v): string {
                 return (string) ($v instanceof BackedEnum ? $v->value : $v);
             },
-            array_values($value)
+            $values,
         );
+
+        $new = clone $this;
+        $new->values = $values;
         return $new;
     }
 

--- a/tests/Tag/SelectTest.php
+++ b/tests/Tag/SelectTest.php
@@ -12,6 +12,8 @@ use Yiisoft\Html\Tag\Select;
 use Yiisoft\Html\Tests\Support\IntegerEnum;
 use Yiisoft\Html\Tests\Support\StringEnum;
 
+use function PHPUnit\Framework\assertSame;
+
 final class SelectTest extends TestCase
 {
     public static function dataProviderName(): array
@@ -570,5 +572,40 @@ final class SelectTest extends TestCase
         $this->assertNotSame($select, $select->required());
         $this->assertNotSame($select, $select->size(0));
         $this->assertNotSame($select, $select->unselectValue(null));
+    }
+
+    public function testNullValue(): void
+    {
+        $select = Select::tag()
+            ->optionsData(['red' => 'RED', 'green' => 'GREEN'])
+            ->value(null);
+
+        assertSame(
+            <<<HTML
+            <select>
+            <option value="red">RED</option>
+            <option value="green">GREEN</option>
+            </select>
+            HTML,
+            $select->render()
+        );
+    }
+
+    public function testNullValueOverride(): void
+    {
+        $select = Select::tag()
+            ->optionsData(['red' => 'RED', 'green' => 'GREEN'])
+            ->value('red')
+            ->value(null);
+
+        assertSame(
+            <<<HTML
+            <select>
+            <option value="red">RED</option>
+            <option value="green">GREEN</option>
+            </select>
+            HTML,
+            $select->render()
+        );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

