### PR TITLE
Allow pass `int`, `float` and `null` as tag content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Chg #234: Remove tag attributes sorting (@FrankiFixx)
 - Chg #269: Rename `$options` parameter to `$attributes` in `Html::addCssClass()`, `Html::removeCssClass()`,
   `Html::addCssStyle()` and `Html::removeCssStyle()` methods (@vjik)
-- New #270: Allow pass `int`, `float` and `null` as tag content (@vjik)
+- New #270: Allow passing `int`, `float` and `null` as tag content (@vjik)
 
 ## 3.13.0 March 13, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Chg #234: Remove tag attributes sorting (@FrankiFixx)
 - Chg #269: Rename `$options` parameter to `$attributes` in `Html::addCssClass()`, `Html::removeCssClass()`,
   `Html::addCssStyle()` and `Html::removeCssStyle()` methods (@vjik)
+- New #270: Allow pass `int`, `float` and `null` as tag content (@vjik)
 
 ## 3.13.0 March 13, 2026
 

--- a/src/Html.php
+++ b/src/Html.php
@@ -261,12 +261,12 @@ final class Html
      * @see CustomTag
      *
      * @param string $name The tag name.
-     * @param string|Stringable $content The tag content.
+     * @param string|Stringable|int|float|null $content The tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      *
      * @psalm-param non-empty-string $name
      */
-    public static function tag(string $name, string|Stringable $content = '', array $attributes = []): CustomTag
+    public static function tag(string $name, string|Stringable|int|float|null $content = '', array $attributes = []): CustomTag
     {
         $tag = new CustomTag($name);
         if ($content !== '') {
@@ -284,12 +284,12 @@ final class Html
      * @see CustomTag
      *
      * @param string $name The tag name.
-     * @param string|Stringable $content The tag content.
+     * @param string|Stringable|int|float|null $content The tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      *
      * @psalm-param non-empty-string $name
      */
-    public static function normalTag(string $name, string|Stringable $content = '', array $attributes = []): CustomTag
+    public static function normalTag(string $name, string|Stringable|int|float|null $content = '', array $attributes = []): CustomTag
     {
         $tag = (new CustomTag($name))->normal();
         if ($content !== '') {
@@ -348,10 +348,10 @@ final class Html
     /**
      * Generates a {@see Style} tag.
      *
-     * @param string $content The style content.
+     * @param string|Stringable $content The style content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function style(string $content = '', array $attributes = []): Style
+    public static function style(string|Stringable $content = '', array $attributes = []): Style
     {
         $tag = new Style();
         if ($content !== '') {
@@ -366,10 +366,10 @@ final class Html
     /**
      * Generates a {@see Script} tag.
      *
-     * @param string $content The script content.
+     * @param string|Stringable $content The script content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function script(string $content = '', array $attributes = []): Script
+    public static function script(string|Stringable $content = '', array $attributes = []): Script
     {
         $tag = new Script();
         if ($content !== '') {
@@ -384,9 +384,9 @@ final class Html
     /**
      * Generates a {@see Noscript} tag.
      *
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable|int|float|null $content Tag content.
      */
-    public static function noscript(string|Stringable $content = ''): Noscript
+    public static function noscript(string|Stringable|int|float|null $content = ''): Noscript
     {
         $tag = new Noscript();
         return $content === '' ? $tag : $tag->content($content);
@@ -395,10 +395,10 @@ final class Html
     /**
      * Generates a {@see Title} tag.
      *
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable|int|float|null $content Tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function title(string|Stringable $content = '', array $attributes = []): Title
+    public static function title(string|Stringable|int|float|null $content = '', array $attributes = []): Title
     {
         $tag = new Title();
         if (!empty($attributes)) {
@@ -472,12 +472,12 @@ final class Html
     /**
      * Generates a hyperlink tag.
      *
-     * @param string|Stringable $content The tag content.
+     * @param string|Stringable|int|float|null $content The tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      *
      * @see A
      */
-    public static function a(string|Stringable $content = '', ?string $url = null, array $attributes = []): A
+    public static function a(string|Stringable|int|float|null $content = '', ?string $url = null, array $attributes = []): A
     {
         $tag = new A();
         if (!empty($attributes)) {
@@ -499,11 +499,11 @@ final class Html
      *
      * @see A
      */
-    public static function mailto(string $content, ?string $mail = null, array $attributes = []): A
+    public static function mailto(string|Stringable|int|float|null $content, ?string $mail = null, array $attributes = []): A
     {
         $tag = (new A())
             ->content($content)
-            ->mailto($mail ?? $content);
+            ->mailto($mail ?? ($content === null ? null : (string) $content));
         if (!empty($attributes)) {
             $tag = $tag->addAttributes($attributes);
         }
@@ -571,11 +571,11 @@ final class Html
     /**
      * Generates a {@see Label} tag.
      *
-     * @param string|Stringable $content Label text.
+     * @param string|Stringable|int|float|null $content Label text.
      * @param string|null $for The ID of the HTML element that this label is associated with.
      * If this is null, the "for" attribute will not be generated.
      */
-    public static function label(string|Stringable $content = '', ?string $for = null): Label
+    public static function label(string|Stringable|int|float|null $content = '', ?string $for = null): Label
     {
         $tag = new Label();
         if ($for !== null) {
@@ -590,10 +590,10 @@ final class Html
     /**
      * Generates a {@see Legend} tag.
      *
-     * @param string|Stringable $content The tag content.
+     * @param string|Stringable|int|float|null $content The tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function legend(string|Stringable $content = '', array $attributes = []): Legend
+    public static function legend(string|Stringable|int|float|null $content = '', array $attributes = []): Legend
     {
         $tag = new Legend();
         if ($content !== '') {
@@ -610,10 +610,10 @@ final class Html
      *
      * @see Button::button()
      *
-     * @param string $content The content enclosed within the button tag.
+     * @param string|Stringable|int|float|null $content The content enclosed within the button tag.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function button(string $content = 'Button', array $attributes = []): Button
+    public static function button(string|Stringable|int|float|null $content = 'Button', array $attributes = []): Button
     {
         $tag = Button::button($content);
         if (!empty($attributes)) {
@@ -627,10 +627,10 @@ final class Html
      *
      * @see Button::submit()
      *
-     * @param string $content The content enclosed within the button tag.
+     * @param string|Stringable|int|float|null $content The content enclosed within the button tag.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function submitButton(string $content = 'Submit', array $attributes = []): Button
+    public static function submitButton(string|Stringable|int|float|null $content = 'Submit', array $attributes = []): Button
     {
         $tag = Button::submit($content);
         if (!empty($attributes)) {
@@ -644,10 +644,10 @@ final class Html
      *
      * @see Button::reset()
      *
-     * @param string $content The content enclosed within the button tag.
+     * @param string|Stringable|int|float|null $content The content enclosed within the button tag.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function resetButton(string $content = 'Reset', array $attributes = []): Button
+    public static function resetButton(string|Stringable|int|float|null $content = 'Reset', array $attributes = []): Button
     {
         $tag = Button::reset($content);
         if (!empty($attributes)) {
@@ -925,11 +925,11 @@ final class Html
     /**
      * Generates a {@see Option} tag.
      *
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable|int|float|null $content Tag content.
      * @param bool|float|int|string|Stringable|null $value The value attribute.
      */
     public static function option(
-        string|Stringable $content = '',
+        string|Stringable|int|float|null $content = '',
         bool|float|int|string|Stringable|null $value = null,
     ): Option {
         $tag = new Option();
@@ -965,10 +965,10 @@ final class Html
     /**
      * Generates a {@see Div} tag.
      *
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable|int|float|null $content Tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function div(string|Stringable $content = '', array $attributes = []): Div
+    public static function div(string|Stringable|int|float|null $content = '', array $attributes = []): Div
     {
         $tag = new Div();
         if (!empty($attributes)) {
@@ -980,12 +980,12 @@ final class Html
     /**
      * Generates a {@see Code} tag.
      *
-     * @param string|Stringable $content Tag content. If content includes HTML tags or special characters like `<`, `>`,
+     * @param string|Stringable|int|float|null $content Tag content. If content includes HTML tags or special characters like `<`, `>`,
      * or `&`, and you want them to be displayed as plain text, you need to enable encoding by calling `->encode(true)`.
      * This ensures they are not interpreted as actual HTML.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function code(string|Stringable $content = '', array $attributes = []): Code
+    public static function code(string|Stringable|int|float|null $content = '', array $attributes = []): Code
     {
         $tag = new Code();
         if (!empty($attributes)) {
@@ -997,12 +997,12 @@ final class Html
     /**
      * Generates a {@see Pre} tag.
      *
-     * @param string|Stringable $content Tag content. If content includes HTML tags or special characters like `<`, `>`,
+     * @param string|Stringable|int|float|null $content Tag content. If content includes HTML tags or special characters like `<`, `>`,
      * or `&`, and you want them to be displayed as plain text, you need to enable encoding by calling `->encode(true)`.
      * This ensures they are not interpreted as actual HTML.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function pre(string|Stringable $content = '', array $attributes = []): Pre
+    public static function pre(string|Stringable|int|float|null $content = '', array $attributes = []): Pre
     {
         $tag = new Pre();
         if (!empty($attributes)) {
@@ -1014,10 +1014,10 @@ final class Html
     /**
      * Generates a {@see Span} tag.
      *
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable|int|float|null $content Tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function span(string|Stringable $content = '', array $attributes = []): Span
+    public static function span(string|Stringable|int|float|null $content = '', array $attributes = []): Span
     {
         $tag = new Span();
         if (!empty($attributes)) {
@@ -1029,10 +1029,10 @@ final class Html
     /**
      * Generates a {@see Em} tag.
      *
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable|int|float|null $content Tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function em(string|Stringable $content = '', array $attributes = []): Em
+    public static function em(string|Stringable|int|float|null $content = '', array $attributes = []): Em
     {
         $tag = new Em();
         if (!empty($attributes)) {
@@ -1044,10 +1044,10 @@ final class Html
     /**
      * Generates a {@see Strong} tag.
      *
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable|int|float|null $content Tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function strong(string|Stringable $content = '', array $attributes = []): Strong
+    public static function strong(string|Stringable|int|float|null $content = '', array $attributes = []): Strong
     {
         $tag = new Strong();
         if (!empty($attributes)) {
@@ -1059,10 +1059,10 @@ final class Html
     /**
      * Generates a {@see Small} tag.
      *
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable|int|float|null $content Tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function small(string|Stringable $content = '', array $attributes = []): Small
+    public static function small(string|Stringable|int|float|null $content = '', array $attributes = []): Small
     {
         $tag = new Small();
         if (!empty($attributes)) {
@@ -1074,10 +1074,10 @@ final class Html
     /**
      * Generates a {@see B} tag.
      *
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable|int|float|null $content Tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function b(string|Stringable $content = '', array $attributes = []): B
+    public static function b(string|Stringable|int|float|null $content = '', array $attributes = []): B
     {
         $tag = new B();
         if (!empty($attributes)) {
@@ -1089,10 +1089,10 @@ final class Html
     /**
      * Generates a {@see I} tag.
      *
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable|int|float|null $content Tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function i(string|Stringable $content = '', array $attributes = []): I
+    public static function i(string|Stringable|int|float|null $content = '', array $attributes = []): I
     {
         $tag = new I();
         if (!empty($attributes)) {
@@ -1104,10 +1104,10 @@ final class Html
     /**
      * Generates a {@see H1} tag.
      *
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable|int|float|null $content Tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function h1(string|Stringable $content = '', array $attributes = []): H1
+    public static function h1(string|Stringable|int|float|null $content = '', array $attributes = []): H1
     {
         $tag = new H1();
         if (!empty($attributes)) {
@@ -1119,10 +1119,10 @@ final class Html
     /**
      * Generates a {@see H2} tag.
      *
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable|int|float|null $content Tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function h2(string|Stringable $content = '', array $attributes = []): H2
+    public static function h2(string|Stringable|int|float|null $content = '', array $attributes = []): H2
     {
         $tag = new H2();
         if (!empty($attributes)) {
@@ -1134,10 +1134,10 @@ final class Html
     /**
      * Generates a {@see H3} tag.
      *
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable|int|float|null $content Tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function h3(string|Stringable $content = '', array $attributes = []): H3
+    public static function h3(string|Stringable|int|float|null $content = '', array $attributes = []): H3
     {
         $tag = new H3();
         if (!empty($attributes)) {
@@ -1149,10 +1149,10 @@ final class Html
     /**
      * Generates a {@see H4} tag.
      *
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable|int|float|null $content Tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function h4(string|Stringable $content = '', array $attributes = []): H4
+    public static function h4(string|Stringable|int|float|null $content = '', array $attributes = []): H4
     {
         $tag = new H4();
         if (!empty($attributes)) {
@@ -1164,10 +1164,10 @@ final class Html
     /**
      * Generates a {@see H5} tag.
      *
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable|int|float|null $content Tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function h5(string|Stringable $content = '', array $attributes = []): H5
+    public static function h5(string|Stringable|int|float|null $content = '', array $attributes = []): H5
     {
         $tag = new H5();
         if (!empty($attributes)) {
@@ -1179,10 +1179,10 @@ final class Html
     /**
      * Generates a {@see H6} tag.
      *
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable|int|float|null $content Tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function h6(string|Stringable $content = '', array $attributes = []): H6
+    public static function h6(string|Stringable|int|float|null $content = '', array $attributes = []): H6
     {
         $tag = new H6();
         if (!empty($attributes)) {
@@ -1194,10 +1194,10 @@ final class Html
     /**
      * Generates a {@see P} tag.
      *
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable|int|float|null $content Tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function p(string|Stringable $content = '', array $attributes = []): P
+    public static function p(string|Stringable|int|float|null $content = '', array $attributes = []): P
     {
         $tag = new P();
         if (!empty($attributes)) {
@@ -1237,10 +1237,10 @@ final class Html
     /**
      * Generates a {@see Li} tag.
      *
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable|int|float|null $content Tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function li(string|Stringable $content = '', array $attributes = []): Li
+    public static function li(string|Stringable|int|float|null $content = '', array $attributes = []): Li
     {
         $tag = new Li();
 
@@ -1268,10 +1268,10 @@ final class Html
     /**
      * Generates a {@see Caption} tag.
      *
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable|int|float|null $content Tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function caption(string|Stringable $content = '', array $attributes = []): Caption
+    public static function caption(string|Stringable|int|float|null $content = '', array $attributes = []): Caption
     {
         $tag = new Caption();
         if ($content !== '') {
@@ -1363,10 +1363,10 @@ final class Html
     /**
      * Generates a {@see Td} tag.
      *
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable|int|float|null $content Tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function td(string|Stringable $content = '', array $attributes = []): Td
+    public static function td(string|Stringable|int|float|null $content = '', array $attributes = []): Td
     {
         $tag = new Td();
         if ($content !== '') {
@@ -1381,10 +1381,10 @@ final class Html
     /**
      * Generates a {@see Th} tag.
      *
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable|int|float|null $content Tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function th(string|Stringable $content = '', array $attributes = []): Th
+    public static function th(string|Stringable|int|float|null $content = '', array $attributes = []): Th
     {
         $tag = new Th();
         if ($content !== '') {
@@ -1448,11 +1448,11 @@ final class Html
     /**
      * Generates a {@see Html} tag.
      *
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable|int|float|null $content Tag content.
      * @param string|null $lang The document language.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function html(string|Stringable $content = '', ?string $lang = null, array $attributes = []): Tag\Html
+    public static function html(string|Stringable|int|float|null $content = '', ?string $lang = null, array $attributes = []): Tag\Html
     {
         $tag = new Tag\Html();
         if (!empty($attributes)) {
@@ -1470,10 +1470,10 @@ final class Html
     /**
      * Generates a {@see Body} tag.
      *
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable|int|float|null $content Tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function body(string|Stringable $content = '', array $attributes = []): Body
+    public static function body(string|Stringable|int|float|null $content = '', array $attributes = []): Body
     {
         $tag = new Body();
         if (!empty($attributes)) {
@@ -1485,10 +1485,10 @@ final class Html
     /**
      * Generates a {@see Article} tag.
      *
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable|int|float|null $content Tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function article(string|Stringable $content = '', array $attributes = []): Article
+    public static function article(string|Stringable|int|float|null $content = '', array $attributes = []): Article
     {
         $tag = new Article();
         if (!empty($attributes)) {
@@ -1500,10 +1500,10 @@ final class Html
     /**
      * Generates a {@see Section} tag.
      *
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable|int|float|null $content Tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function section(string|Stringable $content = '', array $attributes = []): Section
+    public static function section(string|Stringable|int|float|null $content = '', array $attributes = []): Section
     {
         $tag = new Section();
         if (!empty($attributes)) {
@@ -1515,10 +1515,10 @@ final class Html
     /**
      * Generates a {@see Nav} tag.
      *
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable|int|float|null $content Tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function nav(string|Stringable $content = '', array $attributes = []): Nav
+    public static function nav(string|Stringable|int|float|null $content = '', array $attributes = []): Nav
     {
         $tag = new Nav();
         if (!empty($attributes)) {
@@ -1530,10 +1530,10 @@ final class Html
     /**
      * Generates a {@see Aside} tag.
      *
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable|int|float|null $content Tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function aside(string|Stringable $content = '', array $attributes = []): Aside
+    public static function aside(string|Stringable|int|float|null $content = '', array $attributes = []): Aside
     {
         $tag = new Aside();
         if (!empty($attributes)) {
@@ -1545,10 +1545,10 @@ final class Html
     /**
      * Generates a {@see Hgroup} tag.
      *
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable|int|float|null $content Tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function hgroup(string|Stringable $content = '', array $attributes = []): Hgroup
+    public static function hgroup(string|Stringable|int|float|null $content = '', array $attributes = []): Hgroup
     {
         $tag = new Hgroup();
         if (!empty($attributes)) {
@@ -1560,10 +1560,10 @@ final class Html
     /**
      * Generates a {@see Header} tag.
      *
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable|int|float|null $content Tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function header(string|Stringable $content = '', array $attributes = []): Header
+    public static function header(string|Stringable|int|float|null $content = '', array $attributes = []): Header
     {
         $tag = new Header();
         if (!empty($attributes)) {
@@ -1587,10 +1587,10 @@ final class Html
     /**
      * Generates a {@see Footer} tag.
      *
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable|int|float|null $content Tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function footer(string|Stringable $content = '', array $attributes = []): Footer
+    public static function footer(string|Stringable|int|float|null $content = '', array $attributes = []): Footer
     {
         $tag = new Footer();
         if (!empty($attributes)) {
@@ -1602,10 +1602,10 @@ final class Html
     /**
      * Generates a {@see Address} tag.
      *
-     * @param string|Stringable $content Tag content.
+     * @param string|Stringable|int|float|null $content Tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function address(string|Stringable $content = '', array $attributes = []): Address
+    public static function address(string|Stringable|int|float|null $content = '', array $attributes = []): Address
     {
         $tag = new Address();
         if (!empty($attributes)) {

--- a/src/Tag/Base/ListTag.php
+++ b/src/Tag/Base/ListTag.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Html\Tag\Base;
 
+use Stringable;
 use Yiisoft\Html\Tag\Li;
 
 /**
@@ -27,14 +28,14 @@ abstract class ListTag extends NormalTag
     }
 
     /**
-     * @param string[] $strings Array of list items as strings.
+     * @param (string|Stringable|int|float|null)[] $strings Array of list items as strings.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      * @param bool $encode Whether to encode strings passed.
      */
     public function strings(array $strings, array $attributes = [], bool $encode = true): static
     {
         $items = array_map(
-            static fn(string $string) => (new Li())
+            static fn(string|Stringable|int|float|null $string) => (new Li())
                 ->content($string)
                 ->attributes($attributes)
                 ->encode($encode),

--- a/src/Tag/Base/ListTag.php
+++ b/src/Tag/Base/ListTag.php
@@ -28,9 +28,9 @@ abstract class ListTag extends NormalTag
     }
 
     /**
-     * @param (string|Stringable|int|float|null)[] $strings Array of list items as strings.
+     * @param (string|Stringable|int|float|null)[] $strings Array of list item contents.
      * @param array $attributes The tag attributes in terms of name-value pairs.
-     * @param bool $encode Whether to encode strings passed.
+     * @param bool $encode Whether to encode the item contents when rendering.
      */
     public function strings(array $strings, array $attributes = [], bool $encode = true): static
     {

--- a/src/Tag/Base/TagContentTrait.php
+++ b/src/Tag/Base/TagContentTrait.php
@@ -17,7 +17,7 @@ trait TagContentTrait
     private bool $doubleEncode = true;
 
     /**
-     * @psalm-var list<string|Stringable>
+     * @psalm-var list<string|Stringable|int|float|null>
      */
     private array $content = [];
 
@@ -48,9 +48,9 @@ trait TagContentTrait
     }
 
     /**
-     * @param string|Stringable ...$content Tag content.
+     * @param string|Stringable|int|float|null ...$content Tag content.
      */
-    final public function content(string|Stringable ...$content): static
+    final public function content(string|Stringable|int|float|null ...$content): static
     {
         $new = clone $this;
         $new->content = array_values($content);
@@ -58,9 +58,9 @@ trait TagContentTrait
     }
 
     /**
-     * @param string|Stringable ...$content Tag content.
+     * @param string|Stringable|int|float|null ...$content Tag content.
      */
-    final public function addContent(string|Stringable ...$content): static
+    final public function addContent(string|Stringable|int|float|null ...$content): static
     {
         $new = clone $this;
         $new->content = array_merge($new->content, array_values($content));
@@ -79,7 +79,7 @@ trait TagContentTrait
                 $item = Html::encode($item, $this->doubleEncode);
             }
 
-            $content .= $item;
+            $content .= (string) $item;
         }
 
         return $content;

--- a/src/Tag/Button.php
+++ b/src/Tag/Button.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Html\Tag;
 
+use Stringable;
 use Yiisoft\Html\Tag\Base\NormalTag;
 use Yiisoft\Html\Tag\Base\TagContentTrait;
 
@@ -14,21 +15,21 @@ final class Button extends NormalTag
 {
     use TagContentTrait;
 
-    public static function button(string $content = ''): self
+    public static function button(string|Stringable|int|float|null $content = ''): self
     {
         $button = (new self())->content($content);
         $button->attributes['type'] = 'button';
         return $button;
     }
 
-    public static function submit(string $content = ''): self
+    public static function submit(string|Stringable|int|float|null $content = ''): self
     {
         $button = (new self())->content($content);
         $button->attributes['type'] = 'submit';
         return $button;
     }
 
-    public static function reset(string $content = ''): self
+    public static function reset(string|Stringable|int|float|null $content = ''): self
     {
         $button = (new self())->content($content);
         $button->attributes['type'] = 'reset';

--- a/src/Tag/Optgroup.php
+++ b/src/Tag/Optgroup.php
@@ -27,7 +27,7 @@ final class Optgroup extends NormalTag
     /**
      * Options as a set of value-content pairs.
      *
-     * @param string[] $data Value-content set of options.
+     * @param (string|Stringable|int|float|null)[] $data Value-content set of options.
      * @param bool $encode Whether to encode option content.
      * @param array[] $optionsAttributes Array of option attribute sets indexed by option values from {@see $data}.
      */

--- a/src/Tag/Script.php
+++ b/src/Tag/Script.php
@@ -23,12 +23,12 @@ final class Script extends NormalTag
     /**
      * @link https://www.w3.org/TR/html52/semantics-scripting.html#script-content-restrictions
      *
-     * @param string $content Tag content.
+     * @param string|Stringable $content Tag content.
      */
-    public function content(string $content): self
+    public function content(string|Stringable $content): self
     {
         $new = clone $this;
-        $new->content = $content;
+        $new->content = (string) $content;
         return $new;
     }
 

--- a/src/Tag/Select.php
+++ b/src/Tag/Select.php
@@ -17,7 +17,7 @@ use function is_array;
  *
  * @link https://www.w3.org/TR/html52/sec-forms.html#the-select-element
  *
- * @psalm-type OptionsData = array<array-key, string|array<array-key,string>>
+ * @psalm-type OptionsData = array<array-key, string|Stringable|int|float|array<array-key,string|Stringable|int|float>>
  */
 final class Select extends NormalTag
 {
@@ -168,10 +168,10 @@ final class Select extends NormalTag
     }
 
     /**
-     * @param string|null $text Text of the option that has dummy value and is rendered
+     * @param string|Stringable|null $text Text of the option that has dummy value and is rendered
      * as an invitation to select a value.
      */
-    public function prompt(?string $text): self
+    public function prompt(string|Stringable|null $text): self
     {
         $new = clone $this;
         $new->prompt = $text === null ? null : (new Option())

--- a/src/Tag/Select.php
+++ b/src/Tag/Select.php
@@ -17,7 +17,7 @@ use function is_array;
  *
  * @link https://www.w3.org/TR/html52/sec-forms.html#the-select-element
  *
- * @psalm-type OptionsData = array<array-key, string|Stringable|int|float|array<array-key,string|Stringable|int|float>>
+ * @psalm-type OptionsData = array<array-key, string|Stringable|int|float|null|array<array-key,string|Stringable|int|float|null>>
  */
 final class Select extends NormalTag
 {
@@ -168,10 +168,10 @@ final class Select extends NormalTag
     }
 
     /**
-     * @param string|Stringable|null $text Text of the option that has dummy value and is rendered
+     * @param string|Stringable|int|float|null $text Text of the option that has dummy value and is rendered
      * as an invitation to select a value.
      */
-    public function prompt(string|Stringable|null $text): self
+    public function prompt(string|Stringable|int|float|null $text): self
     {
         $new = clone $this;
         $new->prompt = $text === null ? null : (new Option())

--- a/src/Tag/Style.php
+++ b/src/Tag/Style.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Html\Tag;
 
+use Stringable;
 use Yiisoft\Html\Tag\Base\NormalTag;
 
 /**
@@ -14,12 +15,12 @@ final class Style extends NormalTag
     private string $content = '';
 
     /**
-     * @param string $content Tag content.
+     * @param string|Stringable $content Tag content.
      */
-    public function content(string $content): self
+    public function content(string|Stringable $content): self
     {
         $new = clone $this;
-        $new->content = $content;
+        $new->content = (string) $content;
         return $new;
     }
 

--- a/src/Tag/Table.php
+++ b/src/Tag/Table.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Html\Tag;
 
+use Stringable;
 use Yiisoft\Html\Tag\Base\NormalTag;
 
 /**
@@ -44,7 +45,7 @@ final class Table extends NormalTag
         return $new;
     }
 
-    public function captionString(string $content, bool $encode = true): self
+    public function captionString(string|Stringable|int|float|null $content, bool $encode = true): self
     {
         $caption = (new Caption())->content($content);
         if (!$encode) {

--- a/src/Tag/Textarea.php
+++ b/src/Tag/Textarea.php
@@ -40,9 +40,9 @@ final class Textarea extends NormalTag
     }
 
     /**
-     * @param string|string[]|Stringable|null $value
+     * @param string|string[]|Stringable|int|float|null $value
      */
-    public function value(string|Stringable|array|null $value): self
+    public function value(string|Stringable|int|float|array|null $value): self
     {
         $content = is_array($value)
             ? implode("\n", $value)

--- a/src/Tag/Tr.php
+++ b/src/Tag/Tr.php
@@ -59,7 +59,7 @@ final class Tr extends NormalTag
     }
 
     /**
-     * @param string[] $strings Array of header cells ({@see Th}) as strings.
+     * @param (string|Stringable|int|float|null)[] $strings Array of header cells ({@see Th}) contents.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      * @param bool $encode Whether to encode strings passed.
      */
@@ -69,7 +69,7 @@ final class Tr extends NormalTag
     }
 
     /**
-     * @param string[] $strings Array of header cells ({@see Th}) as strings.
+     * @param (string|Stringable|int|float|null)[] $strings Array of header cells ({@see Th}) contents.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      * @param bool $encode Whether to encode strings passed.
      */

--- a/src/Tag/Tr.php
+++ b/src/Tag/Tr.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Html\Tag;
 
+use Stringable;
 use Yiisoft\Html\Tag\Base\NormalTag;
 use Yiisoft\Html\Tag\Base\TableCellTag;
 
@@ -90,14 +91,14 @@ final class Tr extends NormalTag
     }
 
     /**
-     * @param string[] $strings
+     * @param (string|Stringable|int|float|null)[] $strings
      *
      * @return Td[]
      */
     private function makeDataCells(array $strings, array $attributes, bool $encode): array
     {
         return array_map(
-            static fn(string $string) => (new Td())
+            static fn(string|Stringable|int|float|null $string) => (new Td())
                 ->content($string)
                 ->attributes($attributes)
                 ->encode($encode),
@@ -106,14 +107,14 @@ final class Tr extends NormalTag
     }
 
     /**
-     * @param string[] $strings
+     * @param (string|Stringable|int|float|null)[] $strings
      *
      * @return Th[]
      */
     private function makeHeaderCells(array $strings, array $attributes, bool $encode): array
     {
         return array_map(
-            static fn(string $string) => (new Th())
+            static fn(string|Stringable|int|float|null $string) => (new Th())
                 ->content($string)
                 ->attributes($attributes)
                 ->encode($encode),

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -67,6 +67,9 @@ final class HtmlTest extends TestCase
         $this->assertSame('<h1>hello</h1>', Html::tag('h1', 'hello')->render());
         $this->assertSame('<h1 id="main">hello</h1>', Html::tag('h1', 'hello', ['id' => 'main'])->render());
         $this->assertSame('<div><p>Hello</p></div>', Html::tag('div', Html::p('Hello'))->render());
+        $this->assertSame('<h1>42</h1>', Html::tag('h1', 42)->render());
+        $this->assertSame('<h1>3.14</h1>', Html::tag('h1', 3.14)->render());
+        $this->assertSame('<h1></h1>', Html::tag('h1', null)->render());
     }
 
     public function testNormalTag(): void
@@ -76,6 +79,9 @@ final class HtmlTest extends TestCase
         $this->assertSame('<h1>hello</h1>', Html::normalTag('h1', 'hello')->render());
         $this->assertSame('<h1 id="main">hello</h1>', Html::normalTag('h1', 'hello', ['id' => 'main'])->render());
         $this->assertSame('<div><p>Hello</p></div>', Html::normalTag('div', Html::p('Hello'))->render());
+        $this->assertSame('<h1>42</h1>', Html::normalTag('h1', 42)->render());
+        $this->assertSame('<h1>3.14</h1>', Html::normalTag('h1', 3.14)->render());
+        $this->assertSame('<h1></h1>', Html::normalTag('h1', null)->render());
     }
 
     public function testVoidTag(): void
@@ -106,6 +112,10 @@ final class HtmlTest extends TestCase
             '<style id="main">.red{color:#f00}</style>',
             Html::style('.red{color:#f00}', ['id' => 'main'])->render(),
         );
+        $this->assertSame(
+            '<style>body{}</style>',
+            Html::style(new StringableObject('body{}'))->render(),
+        );
     }
 
     public function testScript(): void
@@ -116,6 +126,10 @@ final class HtmlTest extends TestCase
             '<script id="main">alert(15)</script>',
             Html::script('alert(15)', ['id' => 'main'])->render(),
         );
+        $this->assertSame(
+            '<script>alert(1)</script>',
+            Html::script(new StringableObject('alert(1)'))->render(),
+        );
     }
 
     public function testNoscript(): void
@@ -123,6 +137,9 @@ final class HtmlTest extends TestCase
         $this->assertSame('<noscript></noscript>', Html::noscript()->render());
         $this->assertSame('<noscript>hello</noscript>', Html::noscript('hello')->render());
         $this->assertSame('<noscript><div></div></noscript>', Html::noscript(new Div())->render());
+        $this->assertSame('<noscript>42</noscript>', Html::noscript(42)->render());
+        $this->assertSame('<noscript>3.14</noscript>', Html::noscript(3.14)->render());
+        $this->assertSame('<noscript></noscript>', Html::noscript(null)->render());
     }
 
     public function testTitle(): void
@@ -131,6 +148,9 @@ final class HtmlTest extends TestCase
         $this->assertSame('<title>hello</title>', Html::title('hello')->render());
         $this->assertSame('<title id="main">hello</title>', Html::title('hello', ['id' => 'main'])->render());
         $this->assertSame('<title>hello</title>', Html::title(new StringableObject('hello'))->render());
+        $this->assertSame('<title>42</title>', Html::title(42)->render());
+        $this->assertSame('<title>3.14</title>', Html::title(3.14)->render());
+        $this->assertSame('<title></title>', Html::title(null)->render());
     }
 
     public function testMeta(): void
@@ -195,6 +215,9 @@ final class HtmlTest extends TestCase
             Html::a('link', 'https://example.com', ['id' => 'home'])->render(),
         );
         $this->assertSame('<a><span>Hello</span></a>', Html::a(Html::span('Hello'))->render());
+        $this->assertSame('<a>42</a>', Html::a(42)->render());
+        $this->assertSame('<a>3.14</a>', Html::a(3.14)->render());
+        $this->assertSame('<a></a>', Html::a(null)->render());
     }
 
     public function testMailto(): void
@@ -210,6 +233,18 @@ final class HtmlTest extends TestCase
         $this->assertSame(
             '<a href="mailto:info@example.com" id="contact">contact me</a>',
             Html::mailto('contact me', 'info@example.com', ['id' => 'contact'])->render(),
+        );
+        $this->assertSame(
+            '<a href="mailto:42">42</a>',
+            Html::mailto(42)->render(),
+        );
+        $this->assertSame(
+            '<a href="mailto:info@example.com">42</a>',
+            Html::mailto(42, 'info@example.com')->render(),
+        );
+        $this->assertSame(
+            '<a></a>',
+            Html::mailto(null)->render(),
         );
     }
 
@@ -261,6 +296,8 @@ final class HtmlTest extends TestCase
         $this->assertSame('<label for>Name</label>', Html::label('Name', '')->render());
         $this->assertSame('<label for="fieldName">Name</label>', Html::label('Name', 'fieldName')->render());
         $this->assertSame('<label><span>Hello</span></label>', Html::label(Html::span('Hello'))->render());
+        $this->assertSame('<label>42</label>', Html::label(42)->render());
+        $this->assertSame('<label></label>', Html::label(null)->render());
     }
 
     public function testLegend(): void
@@ -277,6 +314,8 @@ final class HtmlTest extends TestCase
             '<legend id="MyLegend">Your data</legend>',
             Html::legend('Your data', ['id' => 'MyLegend'])->render(),
         );
+        $this->assertSame('<legend>42</legend>', Html::legend(42)->render());
+        $this->assertSame('<legend></legend>', Html::legend(null)->render());
     }
 
     public function testButton(): void
@@ -288,6 +327,14 @@ final class HtmlTest extends TestCase
         $this->assertSame(
             '<button type="button" id="main">Button</button>',
             Html::button('Button', ['id' => 'main'])->render(),
+        );
+        $this->assertSame(
+            '<button type="button">42</button>',
+            Html::button(42)->render(),
+        );
+        $this->assertSame(
+            '<button type="button"></button>',
+            Html::button(null)->render(),
         );
     }
 
@@ -301,6 +348,10 @@ final class HtmlTest extends TestCase
             '<button type="submit" id="main">Submit</button>',
             Html::submitButton('Submit', ['id' => 'main'])->render(),
         );
+        $this->assertSame(
+            '<button type="submit">42</button>',
+            Html::submitButton(42)->render(),
+        );
     }
 
     public function testResetButton(): void
@@ -312,6 +363,10 @@ final class HtmlTest extends TestCase
         $this->assertSame(
             '<button type="reset" id="main">Reset</button>',
             Html::resetButton('Reset', ['id' => 'main'])->render(),
+        );
+        $this->assertSame(
+            '<button type="reset">42</button>',
+            Html::resetButton(42)->render(),
         );
     }
 
@@ -515,6 +570,9 @@ final class HtmlTest extends TestCase
         $this->assertSame('<option>test</option>', Html::option('test')->render());
         $this->assertSame('<option value="42">test</option>', Html::option('test', 42)->render());
         $this->assertSame('<option><span>Hello</span></option>', Html::option(Html::span('Hello'))->render());
+        $this->assertSame('<option>42</option>', Html::option(42)->render());
+        $this->assertSame('<option>3.14</option>', Html::option(3.14)->render());
+        $this->assertSame('<option></option>', Html::option(null)->render());
     }
 
     public function testTextarea(): void
@@ -571,6 +629,9 @@ final class HtmlTest extends TestCase
         $this->assertSame('<div>hello</div>', Html::div('hello')->render());
         $this->assertSame('<div id="main">hello</div>', Html::div('hello', ['id' => 'main'])->render());
         $this->assertSame('<div><span>Hello</span></div>', Html::div(Html::span('Hello'))->render());
+        $this->assertSame('<div>42</div>', Html::div(42)->render());
+        $this->assertSame('<div>3.14</div>', Html::div(3.14)->render());
+        $this->assertSame('<div></div>', Html::div(null)->render());
     }
 
     public function testSpan(): void
@@ -579,6 +640,8 @@ final class HtmlTest extends TestCase
         $this->assertSame('<span>hello</span>', Html::span('hello')->render());
         $this->assertSame('<span id="main">hello</span>', Html::span('hello', ['id' => 'main'])->render());
         $this->assertSame('<span><span>Hello</span></span>', Html::span(Html::span('Hello'))->render());
+        $this->assertSame('<span>42</span>', Html::span(42)->render());
+        $this->assertSame('<span></span>', Html::span(null)->render());
     }
 
     public function testEm(): void
@@ -627,6 +690,8 @@ final class HtmlTest extends TestCase
         $this->assertSame('<h1>hello</h1>', Html::h1('hello')->render());
         $this->assertSame('<h1 id="main">hello</h1>', Html::h1('hello', ['id' => 'main'])->render());
         $this->assertSame('<h1><span>Hello</span></h1>', Html::h1(Html::span('Hello'))->render());
+        $this->assertSame('<h1>42</h1>', Html::h1(42)->render());
+        $this->assertSame('<h1></h1>', Html::h1(null)->render());
     }
 
     public function testH2(): void
@@ -675,6 +740,8 @@ final class HtmlTest extends TestCase
         $this->assertSame('<p>hello</p>', Html::p('hello')->render());
         $this->assertSame('<p id="main">hello</p>', Html::p('hello', ['id' => 'main'])->render());
         $this->assertSame('<p><span>Hello</span></p>', Html::p(Html::span('Hello'))->render());
+        $this->assertSame('<p>42</p>', Html::p(42)->render());
+        $this->assertSame('<p></p>', Html::p(null)->render());
     }
 
     public function testUl(): void
@@ -712,6 +779,9 @@ final class HtmlTest extends TestCase
             Html::li('Content', ['class' => 'item', 'id' => 'item-1'])->render(),
         );
         $this->assertSame('<li class="empty"></li>', Html::li(attributes: ['class' => 'empty'])->render());
+        $this->assertSame('<li>42</li>', Html::li(42)->render());
+        $this->assertSame('<li>3.14</li>', Html::li(3.14)->render());
+        $this->assertSame('<li></li>', Html::li(null)->render());
     }
 
     public function testDatalist(): void
@@ -729,6 +799,8 @@ final class HtmlTest extends TestCase
             Html::caption('Hello', ['class' => 'red'])->render(),
         );
         $this->assertSame('<caption><span>Hello</span></caption>', Html::caption(Html::span('Hello'))->render());
+        $this->assertSame('<caption>42</caption>', Html::caption(42)->render());
+        $this->assertSame('<caption></caption>', Html::caption(null)->render());
     }
 
     public function testCol(): void
@@ -779,6 +851,9 @@ final class HtmlTest extends TestCase
         $this->assertSame('<td>Hello</td>', Html::td('Hello')->render());
         $this->assertSame('<td class="red">Hello</td>', Html::td('Hello', ['class' => 'red'])->render());
         $this->assertSame('<td><span>Hello</span></td>', Html::td(Html::span('Hello'))->render());
+        $this->assertSame('<td>42</td>', Html::td(42)->render());
+        $this->assertSame('<td>3.14</td>', Html::td(3.14)->render());
+        $this->assertSame('<td></td>', Html::td(null)->render());
     }
 
     public function testTh(): void
@@ -787,6 +862,8 @@ final class HtmlTest extends TestCase
         $this->assertSame('<th>Hello</th>', Html::th('Hello')->render());
         $this->assertSame('<th class="red">Hello</th>', Html::th('Hello', ['class' => 'red'])->render());
         $this->assertSame('<th><span>Hello</span></th>', Html::th(Html::span('Hello'))->render());
+        $this->assertSame('<th>42</th>', Html::th(42)->render());
+        $this->assertSame('<th></th>', Html::th(null)->render());
     }
 
     public function testBr(): void

--- a/tests/Tag/Base/ListTagTest.php
+++ b/tests/Tag/Base/ListTagTest.php
@@ -22,9 +22,9 @@ final class ListTagTest extends TestCase
 
     public function testStrings(): void
     {
-        $tag = (new TestListTag())->strings(['A', 'B']);
+        $tag = (new TestListTag())->strings(['A', 'B', 1, 2.5, null]);
 
-        $this->assertSame("<test>\n<li>A</li>\n<li>B</li>\n</test>", (string) $tag);
+        $this->assertSame("<test>\n<li>A</li>\n<li>B</li>\n<li>1</li>\n<li>2.5</li>\n<li></li>\n</test>", (string) $tag);
     }
 
     public function testStringsAttributes(): void

--- a/tests/Tag/Base/TagContentTraitTest.php
+++ b/tests/Tag/Base/TagContentTraitTest.php
@@ -57,11 +57,14 @@ final class TagContentTraitTest extends TestCase
                 '<test>Hello &gt; <span>World</span>!</test>',
                 ['Hello', ' > ', (new Span())->content('World'), '!'],
             ],
+            'int' => ['<test>42</test>', 42],
+            'float' => ['<test>3.14</test>', 3.14],
+            'null' => ['<test></test>', null],
         ];
     }
 
     #[DataProvider('dataContent')]
-    public function testContent(string $expected, string|array|Stringable $content): void
+    public function testContent(string $expected, string|int|float|array|Stringable|null $content): void
     {
         $tag = new TestTagContentTrait();
         $tag = is_array($content) ? $tag->content(...$content) : $tag->content($content);
@@ -80,16 +83,36 @@ final class TagContentTraitTest extends TestCase
         );
     }
 
-    public function testAddContent(): void
+    public static function dataAddContent(): array
     {
-        $this->assertSame(
-            '<test>Hello World</test>',
-            (new TestTagContentTrait())
-                ->content('Hello')
-                ->addContent(' ')
-                ->addContent(new StringableObject('World'))
-                ->render(),
-        );
+        return [
+            'stringable' => [
+                '<test>Hello World</test>',
+                'Hello',
+                [' ', new StringableObject('World')],
+            ],
+            'int' => [
+                '<test>Value: 42</test>',
+                'Value: ',
+                [42],
+            ],
+            'float' => [
+                '<test>Value: 3.14</test>',
+                'Value: ',
+                [3.14],
+            ],
+        ];
+    }
+
+    #[DataProvider('dataAddContent')]
+    public function testAddContent(string $expected, string $initial, array $additions): void
+    {
+        $tag = (new TestTagContentTrait())->content($initial);
+        foreach ($additions as $addition) {
+            $tag = $tag->addContent($addition);
+        }
+
+        $this->assertSame($expected, $tag->render());
     }
 
     public function testAddContentVariadic(): void
@@ -115,11 +138,20 @@ final class TagContentTraitTest extends TestCase
         );
     }
 
-    public function testContentArray(): void
+    public static function dataContentArray(): array
     {
-        $tag = (new TestTagContentTrait())->content(a: '1', b: '2');
+        return [
+            'strings' => [['1', '2'], ['a' => '1', 'b' => '2']],
+            'int-float-null' => [[42, 3.14, null], ['a' => 42, 'b' => 3.14, 'c' => null]],
+        ];
+    }
 
-        $this->assertSame(['1', '2'], $tag->getContentArray());
+    #[DataProvider('dataContentArray')]
+    public function testContentArray(array $expected, array $args): void
+    {
+        $tag = (new TestTagContentTrait())->content(...$args);
+
+        $this->assertSame($expected, $tag->getContentArray());
     }
 
     public function testImmutability(): void

--- a/tests/Tag/ButtonTest.php
+++ b/tests/Tag/ButtonTest.php
@@ -20,11 +20,22 @@ final class ButtonTest extends TestCase
         );
     }
 
-    public function testButton(): void
+    public static function dataButton(): array
+    {
+        return [
+            'string' => ['Agree', 'Agree'],
+            'int' => ['42', 42],
+            'float' => ['3.14', 3.14],
+            'null' => ['', null],
+        ];
+    }
+
+    #[DataProvider('dataButton')]
+    public function testButton(string $expectedContent, string|int|float|null $content): void
     {
         $this->assertSame(
-            '<button type="button">Agree</button>',
-            (string) Button::button('Agree'),
+            "<button type=\"button\">$expectedContent</button>",
+            (string) Button::button($content),
         );
     }
 
@@ -36,6 +47,25 @@ final class ButtonTest extends TestCase
         );
     }
 
+    public static function dataSubmit(): array
+    {
+        return [
+            'string' => ['Send', 'Send'],
+            'int' => ['1', 1],
+            'float' => ['3.14', 3.14],
+            'null' => ['', null],
+        ];
+    }
+
+    #[DataProvider('dataSubmit')]
+    public function testSubmit(string $expectedContent, string|int|float|null $content): void
+    {
+        $this->assertSame(
+            "<button type=\"submit\">$expectedContent</button>",
+            (string) Button::submit($content),
+        );
+    }
+
     public function testSubmitWithoutContent(): void
     {
         $this->assertSame(
@@ -44,27 +74,30 @@ final class ButtonTest extends TestCase
         );
     }
 
+    public static function dataReset(): array
+    {
+        return [
+            'string' => ['Reset form', 'Reset form'],
+            'int' => ['1', 1],
+            'float' => ['3.14', 3.14],
+            'null' => ['', null],
+        ];
+    }
+
+    #[DataProvider('dataReset')]
+    public function testReset(string $expectedContent, string|int|float|null $content): void
+    {
+        $this->assertSame(
+            "<button type=\"reset\">$expectedContent</button>",
+            (string) Button::reset($content),
+        );
+    }
+
     public function testResetWithoutContent(): void
     {
         $this->assertSame(
             '<button type="reset"></button>',
             (string) Button::reset(),
-        );
-    }
-
-    public function testSubmit(): void
-    {
-        $this->assertSame(
-            '<button type="submit">Send</button>',
-            (string) Button::submit('Send'),
-        );
-    }
-
-    public function testReset(): void
-    {
-        $this->assertSame(
-            '<button type="reset">Reset form</button>',
-            (string) Button::reset('Reset form'),
         );
     }
 

--- a/tests/Tag/CustomTagTest.php
+++ b/tests/Tag/CustomTagTest.php
@@ -121,11 +121,14 @@ final class CustomTagTest extends TestCase
                 '<test>Hello &gt; <span>World</span>!</test>',
                 ['Hello', ' > ', (new Span())->content('World'), '!'],
             ],
+            'int' => ['<test>42</test>', 42],
+            'float' => ['<test>3.14</test>', 3.14],
+            'null' => ['<test></test>', null],
         ];
     }
 
     #[DataProvider('dataContent')]
-    public function testContent(string $expected, string|array|Stringable $content): void
+    public function testContent(string $expected, string|int|float|array|Stringable|null $content): void
     {
         $tag = new CustomTag('test');
         $tag = is_array($content) ? $tag->content(...$content) : $tag->content($content);

--- a/tests/Tag/OptgroupTest.php
+++ b/tests/Tag/OptgroupTest.php
@@ -53,6 +53,10 @@ final class OptgroupTest extends TestCase
             "<optgroup>\n<option value=\"1\">One</option>\n<option value=\"2\">Two</option>\n</optgroup>",
             (string) (new Optgroup())->optionsData(['1' => 'One', '2' => 'Two']),
         );
+        $this->assertSame(
+            "<optgroup>\n<option value=\"1\">42</option>\n<option value=\"2\">3.14</option>\n</optgroup>",
+            (string) (new Optgroup())->optionsData(['1' => 42, '2' => 3.14]),
+        );
     }
 
     public function testOptionsDataEncode(): void

--- a/tests/Tag/ScriptTest.php
+++ b/tests/Tag/ScriptTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 use Yiisoft\Html\Tag\Div;
 use Yiisoft\Html\Tag\Noscript;
 use Yiisoft\Html\Tag\Script;
+use Yiisoft\Html\Tests\Objects\StringableObject;
 
 final class ScriptTest extends TestCase
 {
@@ -28,6 +29,15 @@ final class ScriptTest extends TestCase
 
         $this->assertSame($content, $tag->getContent());
         $this->assertSame('<script>' . $content . '</script>', $tag->render());
+    }
+
+    public function testContentWithStringable(): void
+    {
+        $content = new StringableObject('alert("hello");');
+        $tag = (new Script())->content($content);
+
+        $this->assertSame('alert("hello");', $tag->getContent());
+        $this->assertSame('<script>alert("hello");</script>', $tag->render());
     }
 
     public static function dataUrl(): array

--- a/tests/Tag/SelectTest.php
+++ b/tests/Tag/SelectTest.php
@@ -6,9 +6,11 @@ namespace Yiisoft\Html\Tests\Tag;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Stringable;
 use Yiisoft\Html\Tag\Optgroup;
 use Yiisoft\Html\Tag\Option;
 use Yiisoft\Html\Tag\Select;
+use Yiisoft\Html\Tests\Objects\StringableObject;
 use Yiisoft\Html\Tests\Support\IntegerEnum;
 use Yiisoft\Html\Tests\Support\StringEnum;
 
@@ -291,6 +293,10 @@ final class SelectTest extends TestCase
             "<select>\n<option value=\"1\">One</option>\n<option value=\"2\">Two</option>\n</select>",
             (string) (new Select())->optionsData(['1' => 'One', '2' => 'Two']),
         );
+        $this->assertSame(
+            "<select>\n<option value=\"1\">42</option>\n<option value=\"2\">3.14</option>\n</select>",
+            (string) (new Select())->optionsData(['1' => 42, '2' => 3.14]),
+        );
     }
 
     public function testOptionsDataEncode(): void
@@ -393,11 +399,18 @@ final class SelectTest extends TestCase
                 . '</select>',
                 'Please select...',
             ],
+            [
+                '<select>' . "\n"
+                . '<option value>Choose an option</option>' . "\n"
+                . '<option value="1">One</option>' . "\n"
+                . '</select>',
+                new StringableObject('Choose an option'),
+            ],
         ];
     }
 
     #[DataProvider('dataPrompt')]
-    public function testPrompt(string $expected, ?string $text): void
+    public function testPrompt(string $expected, string|Stringable|null $text): void
     {
         $this->assertSame(
             $expected,

--- a/tests/Tag/SelectTest.php
+++ b/tests/Tag/SelectTest.php
@@ -297,6 +297,10 @@ final class SelectTest extends TestCase
             "<select>\n<option value=\"1\">42</option>\n<option value=\"2\">3.14</option>\n</select>",
             (string) (new Select())->optionsData(['1' => 42, '2' => 3.14]),
         );
+        $this->assertSame(
+            "<select>\n<option value=\"1\"></option>\n</select>",
+            (string) (new Select())->optionsData(['1' => null]),
+        );
     }
 
     public function testOptionsDataEncode(): void
@@ -323,6 +327,9 @@ final class SelectTest extends TestCase
                 'Test Group' => [
                     2 => 'Two',
                     3 => 'Three',
+                    4 => 42,
+                    5 => 3.14,
+                    6 => null,
                 ],
             ]);
 
@@ -333,6 +340,9 @@ final class SelectTest extends TestCase
             <optgroup label="Test Group">
             <option value="2">Two</option>
             <option value="3">Three</option>
+            <option value="4">42</option>
+            <option value="5">3.14</option>
+            <option value="6"></option>
             </optgroup>
             </select>
             HTML,
@@ -406,11 +416,25 @@ final class SelectTest extends TestCase
                 . '</select>',
                 new StringableObject('Choose an option'),
             ],
+            [
+                '<select>' . "\n"
+                . '<option value>42</option>' . "\n"
+                . '<option value="1">One</option>' . "\n"
+                . '</select>',
+                42,
+            ],
+            [
+                '<select>' . "\n"
+                . '<option value>3.14</option>' . "\n"
+                . '<option value="1">One</option>' . "\n"
+                . '</select>',
+                3.14,
+            ],
         ];
     }
 
     #[DataProvider('dataPrompt')]
-    public function testPrompt(string $expected, string|Stringable|null $text): void
+    public function testPrompt(string $expected, string|Stringable|int|float|null $text): void
     {
         $this->assertSame(
             $expected,

--- a/tests/Tag/StyleTest.php
+++ b/tests/Tag/StyleTest.php
@@ -7,6 +7,7 @@ namespace Yiisoft\Html\Tests\Tag;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Html\Tag\Style;
+use Yiisoft\Html\Tests\Objects\StringableObject;
 
 final class StyleTest extends TestCase
 {
@@ -25,6 +26,15 @@ final class StyleTest extends TestCase
 
         $this->assertSame($content, $tag->getContent());
         $this->assertSame('<style>' . $content . '</style>', $tag->render());
+    }
+
+    public function testContentWithStringable(): void
+    {
+        $content = new StringableObject('body { color: red }');
+        $tag = (new Style())->content($content);
+
+        $this->assertSame('body { color: red }', $tag->getContent());
+        $this->assertSame('<style>body { color: red }</style>', $tag->render());
     }
 
     public static function dataMedia(): array

--- a/tests/Tag/TableTest.php
+++ b/tests/Tag/TableTest.php
@@ -38,12 +38,23 @@ class TableTest extends TestCase
             ->render());
     }
 
-    public function testCaptionString(): void
+    public static function dataCaptionString(): array
+    {
+        return [
+            'string' => ['Hello', 'Hello'],
+            'int' => ['42', 42],
+            'float' => ['3.14', 3.14],
+            'null' => ['', null],
+        ];
+    }
+
+    #[DataProvider('dataCaptionString')]
+    public function testCaptionString(string $expectedContent, string|int|float|null $content): void
     {
         $this->assertSame(
-            "<table>\n<caption>Hello</caption>\n</table>",
+            "<table>\n<caption>$expectedContent</caption>\n</table>",
             (new Table())
-                ->captionString('Hello')
+                ->captionString($content)
                 ->render(),
         );
     }

--- a/tests/Tag/TextareaTest.php
+++ b/tests/Tag/TextareaTest.php
@@ -71,6 +71,8 @@ final class TextareaTest extends TestCase
             ['<textarea></textarea>', new StringableObject('')],
             ['<textarea>content</textarea>', 'content'],
             ['<textarea>content</textarea>', new StringableObject('content')],
+            ['<textarea>42</textarea>', 42],
+            ['<textarea>3.14</textarea>', 3.14],
             [
                 <<<HTML
                 <textarea>a

--- a/tests/Tag/TrTest.php
+++ b/tests/Tag/TrTest.php
@@ -149,9 +149,12 @@ class TrTest extends TestCase
     {
         $tr = (new Tr())
             ->headerStrings(['A'])
-            ->addHeaderStrings(['B', 'C']);
+            ->addHeaderStrings(['B', 'C', 1, 2.5, null]);
 
-        $this->assertSame("<tr>\n<th>A</th>\n<th>B</th>\n<th>C</th>\n</tr>", (string) $tr);
+        $this->assertSame(
+            "<tr>\n<th>A</th>\n<th>B</th>\n<th>C</th>\n<th>1</th>\n<th>2.5</th>\n<th></th>\n</tr>",
+            (string) $tr,
+        );
     }
 
     public function testAddHeaderStringsAttributes(): void

--- a/tests/Tag/TrTest.php
+++ b/tests/Tag/TrTest.php
@@ -48,9 +48,9 @@ class TrTest extends TestCase
     public function testDataStrings(): void
     {
         $tr = (new Tr())
-            ->dataStrings(['A', 'B']);
+            ->dataStrings(['A', 'B', null, 1, 2.5]);
 
-        $this->assertSame("<tr>\n<td>A</td>\n<td>B</td>\n</tr>", (string) $tr);
+        $this->assertSame("<tr>\n<td>A</td>\n<td>B</td>\n<td></td>\n<td>1</td>\n<td>2.5</td>\n</tr>", (string) $tr);
     }
 
     public function testDataStringsAttributes(): void
@@ -116,9 +116,9 @@ class TrTest extends TestCase
     public function testHeaderStrings(): void
     {
         $tr = (new Tr())
-            ->headerStrings(['A', 'B']);
+            ->headerStrings(['A', 'B', 1, 2.5, null]);
 
-        $this->assertSame("<tr>\n<th>A</th>\n<th>B</th>\n</tr>", (string) $tr);
+        $this->assertSame("<tr>\n<th>A</th>\n<th>B</th>\n<th>1</th>\n<th>2.5</th>\n<th></th>\n</tr>", (string) $tr);
     }
 
     public function testHeaderStringsAttributes(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
Fix #151 
