### PR TITLE
Fix #278: Add dedicated classes for missing HTML tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 4.2.1 under development
 
-- New #268: Add dedicated classes for missing HTML tags, including `area`, `base`, `embed`, `object`, and `wbr` (@Mister-42)
+- New #278: Add dedicated classes for missing HTML tags (@Mister-42)
 
 ## 4.2.0 June 05, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 4.2.1 under development
 
-- New #268: Add dedicated classes for missing HTML tags (@Mister-42)
+- New #268: Add dedicated classes for missing HTML tags, including `area`, `base`, `embed`, `object`, and `wbr` (@Mister-42)
 
 ## 4.2.0 June 05, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 4.2.1 under development
 
-- no changes in this release.
+- New #268: Add dedicated classes for missing HTML tags (@Mister-42)
 
 ## 4.2.0 June 05, 2026
 

--- a/README.md
+++ b/README.md
@@ -254,7 +254,9 @@ Overall the helper has the following method groups.
 #### Base tags
 
 - abbr
+- area
 - b
+- base
 - bdi
 - bdo
 - br
@@ -265,6 +267,7 @@ Overall the helper has the following method groups.
 - dfn
 - div
 - em
+- embed
 - hr
 - i
 - ins
@@ -291,6 +294,7 @@ Overall the helper has the following method groups.
 - title
 - u
 - var
+- wbr
 
 #### Media tags
 
@@ -386,6 +390,7 @@ Overall the helper has the following method groups.
 - canvas
 - iframe
 - map
+- object
 - slot
 - template
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,15 @@
 
 The package provides various tools to help with dynamic server-side generation of HTML:
 
-- Tag classes `A`, `Address`, `Article`, `Aside`, `Audio`, `B`, `Body`, `Br`, `Button`, `Caption`, `Col`, `Colgroup`,
- `Datalist`, `Div`, `Em`, `Fieldset`, `Footer`, `Form`, `H1`, `H2`, `H3`, `H4`, `H5`, `H6`, `Header`, `Hr`, `Hgroup`,
- `Html`, `I`, `Img`, `Input` (and specialized `Checkbox`, `Radio`, `Range`, `File`, `Color`), `Label`, `Legend`, `Li`, `Link`,
- `Meta`, `Nav`, `Noscript`, `Ol`, `Optgroup`, `Option`, `P`, `Picture`, `Script`, `Section`, `Select`, `Small`,
- `Source`, `Span`, `Strong`, `Style`, `Table`, `Tbody`, `Td`, `Textarea`, `Tfoot`, `Th`, `Thead`, `Title`, `Tr`,
- `Track`, `Ul`, `Video`.
+- Tag classes `A`, `Abbr`, `Address`, `Article`, `Aside`, `Audio`, `B`, `Bdi`, `Bdo`, `Blockquote`, `Body`, `Br`,
+ `Button`, `Canvas`, `Caption`, `Cite`, `Code`, `Col`, `Colgroup`, `CustomTag`, `Data`, `Datalist`, `Dd`, `Del`,
+ `Details`, `Dfn`, `Dialog`, `Div`, `Dl`, `Dt`, `Em`, `Fieldset`, `Figcaption`, `Figure`, `Footer`, `Form`,
+ `H1`, `H2`, `H3`, `H4`, `H5`, `H6`, `Head`, `Header`, `Hgroup`, `Hr`, `Html`, `I`, `Iframe`, `Img`,
+ `Input` (and specialized `Checkbox`, `Radio`, `Range`, `File`, `Color`), `Ins`, `Kbd`, `Label`, `Legend`, `Li`, `Link`,
+ `Main`, `Map`, `Mark`, `Menu`, `Meta`, `Meter`, `Nav`, `Noscript`, `Ol`, `Optgroup`, `Option`, `Output`, `P`,
+ `Picture`, `Pre`, `Progress`, `Q`, `Rp`, `Rt`, `Ruby`, `S`, `Samp`, `Script`, `Search`, `Section`, `Select`,
+ `Slot`, `Small`, `Source`, `Span`, `Strong`, `Style`, `Sub`, `Summary`, `Sup`, `Table`, `Tbody`, `Td`, `Template`,
+ `Textarea`, `Tfoot`, `Th`, `Thead`, `Time`, `Title`, `Tr`, `Track`, `U`, `Ul`, `Var_`, `Video`.
 - `CustomTag` class that helps to generate custom tag with any attributes.
 - HTML widgets `ButtonGroup`, `CheckboxList` and `RadioList`.
 - All tags content is automatically HTML-encoded. There is `NoEncode` class designed to wrap content that should not be encoded.
@@ -250,21 +253,44 @@ Overall the helper has the following method groups.
 
 #### Base tags
 
+- abbr
 - b
+- bdi
+- bdo
+- br
+- cite
+- code
+- data
+- del
+- dfn
 - div
 - em
-- i
 - hr
+- i
+- ins
+- kbd
+- mark
 - meta
-- p
-- br
-- script
 - noscript
+- p
+- pre
+- q
+- rp
+- rt
+- ruby
+- s
+- samp
+- script
+- small
 - span
 - strong
-- small
 - style
+- sub
+- sup
+- time
 - title
+- u
+- var
 
 #### Media tags
 
@@ -287,6 +313,7 @@ Overall the helper has the following method groups.
 #### Section tags
 
 - html
+- head
 - body
 - article
 - section
@@ -296,12 +323,18 @@ Overall the helper has the following method groups.
 - header
 - footer
 - address
+- main
+- search
 
 #### List tags
 
 - ul
 - ol
 - li
+- dl
+- dt
+- dd
+- menu
 
 #### Hyperlink tags
 
@@ -341,6 +374,20 @@ Overall the helper has the following method groups.
 - submitInput
 - textarea
 - textInput
+
+#### Interactive tags
+
+- details
+- dialog
+- summary
+
+#### Embedded content tags
+
+- canvas
+- iframe
+- map
+- slot
+- template
 
 #### Table tags
 

--- a/README.md
+++ b/README.md
@@ -17,15 +17,7 @@
 
 The package provides various tools to help with dynamic server-side generation of HTML:
 
-- Tag classes `A`, `Abbr`, `Address`, `Article`, `Aside`, `Audio`, `B`, `Bdi`, `Bdo`, `Blockquote`, `Body`, `Br`,
- `Button`, `Canvas`, `Caption`, `Cite`, `Code`, `Col`, `Colgroup`, `CustomTag`, `Data`, `Datalist`, `Dd`, `Del`,
- `Details`, `Dfn`, `Dialog`, `Div`, `Dl`, `Dt`, `Em`, `Fieldset`, `Figcaption`, `Figure`, `Footer`, `Form`,
- `H1`, `H2`, `H3`, `H4`, `H5`, `H6`, `Head`, `Header`, `Hgroup`, `Hr`, `Html`, `I`, `Iframe`, `Img`,
- `Input` (and specialized `Checkbox`, `Radio`, `Range`, `File`, `Color`), `Ins`, `Kbd`, `Label`, `Legend`, `Li`, `Link`,
- `Main`, `Map`, `Mark`, `Menu`, `Meta`, `Meter`, `Nav`, `Noscript`, `Ol`, `Optgroup`, `Option`, `Output`, `P`,
- `Picture`, `Pre`, `Progress`, `Q`, `Rp`, `Rt`, `Ruby`, `S`, `Samp`, `Script`, `Search`, `Section`, `Select`,
- `Slot`, `Small`, `Source`, `Span`, `Strong`, `Style`, `Sub`, `Summary`, `Sup`, `Table`, `Tbody`, `Td`, `Template`,
- `Textarea`, `Tfoot`, `Th`, `Thead`, `Time`, `Title`, `Tr`, `Track`, `U`, `Ul`, `Var_`, `Video`.
+- A dedicated class per HTML tag (`A`, `Code`, `Form`, `Img`, `P`, `Select`, …).
 - `CustomTag` class that helps to generate custom tag with any attributes.
 - HTML widgets `ButtonGroup`, `CheckboxList` and `RadioList`.
 - All tags content is automatically HTML-encoded. There is `NoEncode` class designed to wrap content that should not be encoded.
@@ -259,6 +251,7 @@ Overall the helper has the following method groups.
 - base
 - bdi
 - bdo
+- blockquote
 - br
 - cite
 - code
@@ -268,15 +261,20 @@ Overall the helper has the following method groups.
 - div
 - em
 - embed
+- figcaption
+- figure
 - hr
 - i
 - ins
 - kbd
 - mark
 - meta
+- meter
 - noscript
+- output
 - p
 - pre
+- progress
 - q
 - rp
 - rt

--- a/src/Html.php
+++ b/src/Html.php
@@ -9,21 +9,40 @@ use InvalidArgumentException;
 use JsonException;
 use Stringable;
 use Yiisoft\Html\Tag\A;
+use Yiisoft\Html\Tag\Abbr;
 use Yiisoft\Html\Tag\Address;
 use Yiisoft\Html\Tag\Article;
 use Yiisoft\Html\Tag\Aside;
+use Yiisoft\Html\Tag\Audio;
 use Yiisoft\Html\Tag\B;
+use Yiisoft\Html\Tag\Bdi;
+use Yiisoft\Html\Tag\Bdo;
+use Yiisoft\Html\Tag\Blockquote;
+use Yiisoft\Html\Tag\Body;
 use Yiisoft\Html\Tag\Br;
 use Yiisoft\Html\Tag\Button;
+use Yiisoft\Html\Tag\Canvas;
 use Yiisoft\Html\Tag\Caption;
+use Yiisoft\Html\Tag\Cite;
 use Yiisoft\Html\Tag\Code;
 use Yiisoft\Html\Tag\Col;
 use Yiisoft\Html\Tag\Colgroup;
 use Yiisoft\Html\Tag\CustomTag;
+use Yiisoft\Html\Tag\Data;
 use Yiisoft\Html\Tag\Datalist;
+use Yiisoft\Html\Tag\Dd;
+use Yiisoft\Html\Tag\Del;
+use Yiisoft\Html\Tag\Details;
+use Yiisoft\Html\Tag\Dfn;
+use Yiisoft\Html\Tag\Dialog;
 use Yiisoft\Html\Tag\Div;
+use Yiisoft\Html\Tag\Dl;
+use Yiisoft\Html\Tag\Dt;
 use Yiisoft\Html\Tag\Em;
 use Yiisoft\Html\Tag\Fieldset;
+use Yiisoft\Html\Tag\Figcaption;
+use Yiisoft\Html\Tag\Figure;
+use Yiisoft\Html\Tag\Footer;
 use Yiisoft\Html\Tag\Form;
 use Yiisoft\Html\Tag\H1;
 use Yiisoft\Html\Tag\H2;
@@ -31,7 +50,12 @@ use Yiisoft\Html\Tag\H3;
 use Yiisoft\Html\Tag\H4;
 use Yiisoft\Html\Tag\H5;
 use Yiisoft\Html\Tag\H6;
+use Yiisoft\Html\Tag\Head;
+use Yiisoft\Html\Tag\Header;
+use Yiisoft\Html\Tag\Hgroup;
+use Yiisoft\Html\Tag\Hr;
 use Yiisoft\Html\Tag\I;
+use Yiisoft\Html\Tag\Iframe;
 use Yiisoft\Html\Tag\Img;
 use Yiisoft\Html\Tag\Input;
 use Yiisoft\Html\Tag\Input\Checkbox;
@@ -39,45 +63,63 @@ use Yiisoft\Html\Tag\Input\Color;
 use Yiisoft\Html\Tag\Input\File;
 use Yiisoft\Html\Tag\Input\Radio;
 use Yiisoft\Html\Tag\Input\Range;
+use Yiisoft\Html\Tag\Ins;
+use Yiisoft\Html\Tag\Kbd;
 use Yiisoft\Html\Tag\Label;
 use Yiisoft\Html\Tag\Legend;
 use Yiisoft\Html\Tag\Li;
 use Yiisoft\Html\Tag\Link;
-use Yiisoft\Html\Tag\Audio;
-use Yiisoft\Html\Tag\Body;
-use Yiisoft\Html\Tag\Footer;
-use Yiisoft\Html\Tag\Header;
-use Yiisoft\Html\Tag\Hgroup;
-use Yiisoft\Html\Tag\Hr;
-use Yiisoft\Html\Tag\Pre;
-use Yiisoft\Html\Tag\Small;
-use Yiisoft\Html\Tag\Track;
-use Yiisoft\Html\Tag\Video;
+use Yiisoft\Html\Tag\Main;
+use Yiisoft\Html\Tag\Map;
+use Yiisoft\Html\Tag\Mark;
+use Yiisoft\Html\Tag\Menu;
 use Yiisoft\Html\Tag\Meta;
+use Yiisoft\Html\Tag\Meter;
 use Yiisoft\Html\Tag\Nav;
 use Yiisoft\Html\Tag\Noscript;
 use Yiisoft\Html\Tag\Ol;
 use Yiisoft\Html\Tag\Optgroup;
 use Yiisoft\Html\Tag\Option;
+use Yiisoft\Html\Tag\Output;
 use Yiisoft\Html\Tag\P;
 use Yiisoft\Html\Tag\Picture;
+use Yiisoft\Html\Tag\Pre;
+use Yiisoft\Html\Tag\Progress;
+use Yiisoft\Html\Tag\Q;
+use Yiisoft\Html\Tag\Rp;
+use Yiisoft\Html\Tag\Rt;
+use Yiisoft\Html\Tag\Ruby;
+use Yiisoft\Html\Tag\S;
+use Yiisoft\Html\Tag\Samp;
 use Yiisoft\Html\Tag\Script;
+use Yiisoft\Html\Tag\Search;
 use Yiisoft\Html\Tag\Section;
 use Yiisoft\Html\Tag\Select;
+use Yiisoft\Html\Tag\Slot;
+use Yiisoft\Html\Tag\Small;
 use Yiisoft\Html\Tag\Source;
 use Yiisoft\Html\Tag\Span;
 use Yiisoft\Html\Tag\Strong;
 use Yiisoft\Html\Tag\Style;
+use Yiisoft\Html\Tag\Sub;
+use Yiisoft\Html\Tag\Summary;
+use Yiisoft\Html\Tag\Sup;
 use Yiisoft\Html\Tag\Table;
 use Yiisoft\Html\Tag\Tbody;
 use Yiisoft\Html\Tag\Td;
+use Yiisoft\Html\Tag\Template;
 use Yiisoft\Html\Tag\Textarea;
 use Yiisoft\Html\Tag\Tfoot;
 use Yiisoft\Html\Tag\Th;
 use Yiisoft\Html\Tag\Thead;
+use Yiisoft\Html\Tag\Time;
 use Yiisoft\Html\Tag\Title;
 use Yiisoft\Html\Tag\Tr;
+use Yiisoft\Html\Tag\Track;
+use Yiisoft\Html\Tag\U;
 use Yiisoft\Html\Tag\Ul;
+use Yiisoft\Html\Tag\Var_;
+use Yiisoft\Html\Tag\Video;
 use Yiisoft\Html\Widget\CheckboxList\CheckboxList;
 use Yiisoft\Html\Widget\RadioList\RadioList;
 use Yiisoft\Json\Json;
@@ -1602,6 +1644,635 @@ final class Html
     public static function address(string|Stringable|int|float|null $content = '', array $attributes = []): Address
     {
         $tag = new Address();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Abbr} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function abbr(string|Stringable|int|float|null $content = '', array $attributes = []): Abbr
+    {
+        $tag = new Abbr();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Bdi} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function bdi(string|Stringable|int|float|null $content = '', array $attributes = []): Bdi
+    {
+        $tag = new Bdi();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Bdo} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function bdo(string|Stringable|int|float|null $content = '', array $attributes = []): Bdo
+    {
+        $tag = new Bdo();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Blockquote} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function blockquote(string|Stringable|int|float|null $content = '', array $attributes = []): Blockquote
+    {
+        $tag = new Blockquote();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Canvas} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function canvas(string|Stringable|int|float|null $content = '', array $attributes = []): Canvas
+    {
+        $tag = new Canvas();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Cite} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function cite(string|Stringable|int|float|null $content = '', array $attributes = []): Cite
+    {
+        $tag = new Cite();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Data} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function data(string|Stringable|int|float|null $content = '', array $attributes = []): Data
+    {
+        $tag = new Data();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Dd} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function dd(string|Stringable|int|float|null $content = '', array $attributes = []): Dd
+    {
+        $tag = new Dd();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Del} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function del(string|Stringable|int|float|null $content = '', array $attributes = []): Del
+    {
+        $tag = new Del();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Details} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function details(string|Stringable|int|float|null $content = '', array $attributes = []): Details
+    {
+        $tag = new Details();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Dfn} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function dfn(string|Stringable|int|float|null $content = '', array $attributes = []): Dfn
+    {
+        $tag = new Dfn();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Dialog} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function dialog(string|Stringable|int|float|null $content = '', array $attributes = []): Dialog
+    {
+        $tag = new Dialog();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Dl} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function dl(string|Stringable|int|float|null $content = '', array $attributes = []): Dl
+    {
+        $tag = new Dl();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Dt} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function dt(string|Stringable|int|float|null $content = '', array $attributes = []): Dt
+    {
+        $tag = new Dt();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Figcaption} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function figcaption(string|Stringable|int|float|null $content = '', array $attributes = []): Figcaption
+    {
+        $tag = new Figcaption();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Figure} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function figure(string|Stringable|int|float|null $content = '', array $attributes = []): Figure
+    {
+        $tag = new Figure();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Head} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function head(string|Stringable|int|float|null $content = '', array $attributes = []): Head
+    {
+        $tag = new Head();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Iframe} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function iframe(string|Stringable|int|float|null $content = '', array $attributes = []): Iframe
+    {
+        $tag = new Iframe();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Ins} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function ins(string|Stringable|int|float|null $content = '', array $attributes = []): Ins
+    {
+        $tag = new Ins();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Kbd} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function kbd(string|Stringable|int|float|null $content = '', array $attributes = []): Kbd
+    {
+        $tag = new Kbd();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Main} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function main(string|Stringable|int|float|null $content = '', array $attributes = []): Main
+    {
+        $tag = new Main();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Map} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function map(string|Stringable|int|float|null $content = '', array $attributes = []): Map
+    {
+        $tag = new Map();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Mark} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function mark(string|Stringable|int|float|null $content = '', array $attributes = []): Mark
+    {
+        $tag = new Mark();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Menu} tag.
+     *
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function menu(array $attributes = []): Menu
+    {
+        $tag = new Menu();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $tag;
+    }
+
+    /**
+     * Generates a {@see Meter} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function meter(string|Stringable|int|float|null $content = '', array $attributes = []): Meter
+    {
+        $tag = new Meter();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Output} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function output(string|Stringable|int|float|null $content = '', array $attributes = []): Output
+    {
+        $tag = new Output();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Progress} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function progress(string|Stringable|int|float|null $content = '', array $attributes = []): Progress
+    {
+        $tag = new Progress();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Q} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function q(string|Stringable|int|float|null $content = '', array $attributes = []): Q
+    {
+        $tag = new Q();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Rp} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function rp(string|Stringable|int|float|null $content = '', array $attributes = []): Rp
+    {
+        $tag = new Rp();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Rt} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function rt(string|Stringable|int|float|null $content = '', array $attributes = []): Rt
+    {
+        $tag = new Rt();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Ruby} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function ruby(string|Stringable|int|float|null $content = '', array $attributes = []): Ruby
+    {
+        $tag = new Ruby();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see S} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function s(string|Stringable|int|float|null $content = '', array $attributes = []): S
+    {
+        $tag = new S();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Samp} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function samp(string|Stringable|int|float|null $content = '', array $attributes = []): Samp
+    {
+        $tag = new Samp();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Search} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function search(string|Stringable|int|float|null $content = '', array $attributes = []): Search
+    {
+        $tag = new Search();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Slot} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function slot(string|Stringable|int|float|null $content = '', array $attributes = []): Slot
+    {
+        $tag = new Slot();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Sub} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function sub(string|Stringable|int|float|null $content = '', array $attributes = []): Sub
+    {
+        $tag = new Sub();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Summary} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function summary(string|Stringable|int|float|null $content = '', array $attributes = []): Summary
+    {
+        $tag = new Summary();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Sup} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function sup(string|Stringable|int|float|null $content = '', array $attributes = []): Sup
+    {
+        $tag = new Sup();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Template} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function template(string|Stringable|int|float|null $content = '', array $attributes = []): Template
+    {
+        $tag = new Template();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Time} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function time(string|Stringable|int|float|null $content = '', array $attributes = []): Time
+    {
+        $tag = new Time();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see U} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function u(string|Stringable|int|float|null $content = '', array $attributes = []): U
+    {
+        $tag = new U();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Var_} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function var(string|Stringable|int|float|null $content = '', array $attributes = []): Var_
+    {
+        $tag = new Var_();
         if (!empty($attributes)) {
             $tag = $tag->attributes($attributes);
         }

--- a/src/Html.php
+++ b/src/Html.php
@@ -80,7 +80,7 @@ use Yiisoft\Html\Tag\Meta;
 use Yiisoft\Html\Tag\Meter;
 use Yiisoft\Html\Tag\Nav;
 use Yiisoft\Html\Tag\Noscript;
-use Yiisoft\Html\Tag\Object_;
+use Yiisoft\Html\Tag\ObjectTag;
 use Yiisoft\Html\Tag\Ol;
 use Yiisoft\Html\Tag\Optgroup;
 use Yiisoft\Html\Tag\Option;
@@ -122,7 +122,7 @@ use Yiisoft\Html\Tag\Tr;
 use Yiisoft\Html\Tag\Track;
 use Yiisoft\Html\Tag\U;
 use Yiisoft\Html\Tag\Ul;
-use Yiisoft\Html\Tag\Var_;
+use Yiisoft\Html\Tag\VarTag;
 use Yiisoft\Html\Tag\Video;
 use Yiisoft\Html\Tag\Wbr;
 use Yiisoft\Html\Widget\CheckboxList\CheckboxList;
@@ -1967,16 +1967,19 @@ final class Html
     /**
      * Generates a {@see Iframe} tag.
      *
-     * @param string|Stringable|int|float|null $content Tag content.
+     * @param string|null $src The src attribute value.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function iframe(string|Stringable|int|float|null $content = '', array $attributes = []): Iframe
+    public static function iframe(?string $src = null, array $attributes = []): Iframe
     {
         $tag = new Iframe();
         if (!empty($attributes)) {
             $tag = $tag->attributes($attributes);
         }
-        return $content === '' ? $tag : $tag->content($content);
+        if ($src !== null) {
+            $tag = $tag->src($src);
+        }
+        return $tag;
     }
 
     /**
@@ -2084,14 +2087,14 @@ final class Html
     }
 
     /**
-     * Generates a {@see Object_} tag.
+     * Generates a {@see ObjectTag} tag.
      *
      * @param string|Stringable|int|float|null $content Tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function object(string|Stringable|int|float|null $content = '', array $attributes = []): Object_
+    public static function object(string|Stringable|int|float|null $content = '', array $attributes = []): ObjectTag
     {
-        $tag = new Object_();
+        $tag = new ObjectTag();
         if (!empty($attributes)) {
             $tag = $tag->attributes($attributes);
         }
@@ -2339,14 +2342,14 @@ final class Html
     }
 
     /**
-     * Generates a {@see Var_} tag.
+     * Generates a {@see VarTag} tag.
      *
      * @param string|Stringable|int|float|null $content Tag content.
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public static function var(string|Stringable|int|float|null $content = '', array $attributes = []): Var_
+    public static function var(string|Stringable|int|float|null $content = '', array $attributes = []): VarTag
     {
-        $tag = new Var_();
+        $tag = new VarTag();
         if (!empty($attributes)) {
             $tag = $tag->attributes($attributes);
         }

--- a/src/Html.php
+++ b/src/Html.php
@@ -11,10 +11,12 @@ use Stringable;
 use Yiisoft\Html\Tag\A;
 use Yiisoft\Html\Tag\Abbr;
 use Yiisoft\Html\Tag\Address;
+use Yiisoft\Html\Tag\Area;
 use Yiisoft\Html\Tag\Article;
 use Yiisoft\Html\Tag\Aside;
 use Yiisoft\Html\Tag\Audio;
 use Yiisoft\Html\Tag\B;
+use Yiisoft\Html\Tag\Base;
 use Yiisoft\Html\Tag\Bdi;
 use Yiisoft\Html\Tag\Bdo;
 use Yiisoft\Html\Tag\Blockquote;
@@ -39,6 +41,7 @@ use Yiisoft\Html\Tag\Div;
 use Yiisoft\Html\Tag\Dl;
 use Yiisoft\Html\Tag\Dt;
 use Yiisoft\Html\Tag\Em;
+use Yiisoft\Html\Tag\Embed;
 use Yiisoft\Html\Tag\Fieldset;
 use Yiisoft\Html\Tag\Figcaption;
 use Yiisoft\Html\Tag\Figure;
@@ -77,6 +80,7 @@ use Yiisoft\Html\Tag\Meta;
 use Yiisoft\Html\Tag\Meter;
 use Yiisoft\Html\Tag\Nav;
 use Yiisoft\Html\Tag\Noscript;
+use Yiisoft\Html\Tag\Object_;
 use Yiisoft\Html\Tag\Ol;
 use Yiisoft\Html\Tag\Optgroup;
 use Yiisoft\Html\Tag\Option;
@@ -120,6 +124,7 @@ use Yiisoft\Html\Tag\U;
 use Yiisoft\Html\Tag\Ul;
 use Yiisoft\Html\Tag\Var_;
 use Yiisoft\Html\Tag\Video;
+use Yiisoft\Html\Tag\Wbr;
 use Yiisoft\Html\Widget\CheckboxList\CheckboxList;
 use Yiisoft\Html\Widget\RadioList\RadioList;
 use Yiisoft\Json\Json;
@@ -1666,6 +1671,42 @@ final class Html
     }
 
     /**
+     * Generates a {@see Area} tag.
+     *
+     * @param string|null $alt The alternate text for the area.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function area(?string $alt = null, array $attributes = []): Area
+    {
+        $tag = new Area();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        if ($alt !== null) {
+            $tag = $tag->alt($alt);
+        }
+        return $tag;
+    }
+
+    /**
+     * Generates a {@see Base} tag.
+     *
+     * @param string|null $url The base URL for the document.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function base(?string $url = null, array $attributes = []): Base
+    {
+        $tag = new Base();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        if ($url !== null) {
+            $tag = $tag->href($url);
+        }
+        return $tag;
+    }
+
+    /**
      * Generates a {@see Bdi} tag.
      *
      * @param string|Stringable|int|float|null $content Tag content.
@@ -1861,6 +1902,24 @@ final class Html
     }
 
     /**
+     * Generates a {@see Embed} tag.
+     *
+     * @param string|null $src The URL of the embedded resource.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function embed(?string $src = null, array $attributes = []): Embed
+    {
+        $tag = new Embed();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        if ($src !== null) {
+            $tag = $tag->src($src);
+        }
+        return $tag;
+    }
+
+    /**
      * Generates a {@see Figcaption} tag.
      *
      * @param string|Stringable|int|float|null $content Tag content.
@@ -2018,6 +2077,21 @@ final class Html
     public static function meter(string|Stringable|int|float|null $content = '', array $attributes = []): Meter
     {
         $tag = new Meter();
+        if (!empty($attributes)) {
+            $tag = $tag->attributes($attributes);
+        }
+        return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Object_} tag.
+     *
+     * @param string|Stringable|int|float|null $content Tag content.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public static function object(string|Stringable|int|float|null $content = '', array $attributes = []): Object_
+    {
+        $tag = new Object_();
         if (!empty($attributes)) {
             $tag = $tag->attributes($attributes);
         }
@@ -2277,6 +2351,14 @@ final class Html
             $tag = $tag->attributes($attributes);
         }
         return $content === '' ? $tag : $tag->content($content);
+    }
+
+    /**
+     * Generates a {@see Wbr} tag.
+     */
+    public static function wbr(): Wbr
+    {
+        return new Wbr();
     }
 
     /**

--- a/src/Tag/Abbr.php
+++ b/src/Tag/Abbr.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-abbr-element
+ */
+final class Abbr extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'abbr';
+    }
+}

--- a/src/Tag/Area.php
+++ b/src/Tag/Area.php
@@ -46,13 +46,6 @@ final class Area extends VoidTag
         return $new;
     }
 
-    public function media(?string $media): self
-    {
-        $new = clone $this;
-        $new->attributes['media'] = $media;
-        return $new;
-    }
-
     public function referrerpolicy(?string $policy): self
     {
         $new = clone $this;

--- a/src/Tag/Area.php
+++ b/src/Tag/Area.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\VoidTag;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element
+ */
+final class Area extends VoidTag
+{
+    public function alt(?string $text): self
+    {
+        $new = clone $this;
+        $new->attributes['alt'] = $text;
+        return $new;
+    }
+
+    public function coords(?string $coords): self
+    {
+        $new = clone $this;
+        $new->attributes['coords'] = $coords;
+        return $new;
+    }
+
+    public function download(?string $value): self
+    {
+        $new = clone $this;
+        $new->attributes['download'] = $value;
+        return $new;
+    }
+
+    public function href(?string $url): self
+    {
+        $new = clone $this;
+        $new->attributes['href'] = $url;
+        return $new;
+    }
+
+    public function hreflang(?string $lang): self
+    {
+        $new = clone $this;
+        $new->attributes['hreflang'] = $lang;
+        return $new;
+    }
+
+    public function media(?string $media): self
+    {
+        $new = clone $this;
+        $new->attributes['media'] = $media;
+        return $new;
+    }
+
+    public function referrerpolicy(?string $policy): self
+    {
+        $new = clone $this;
+        $new->attributes['referrerpolicy'] = $policy;
+        return $new;
+    }
+
+    public function rel(?string $rel): self
+    {
+        $new = clone $this;
+        $new->attributes['rel'] = $rel;
+        return $new;
+    }
+
+    public function shape(?string $shape): self
+    {
+        $new = clone $this;
+        $new->attributes['shape'] = $shape;
+        return $new;
+    }
+
+    public function target(?string $target): self
+    {
+        $new = clone $this;
+        $new->attributes['target'] = $target;
+        return $new;
+    }
+
+    public function type(?string $type): self
+    {
+        $new = clone $this;
+        $new->attributes['type'] = $type;
+        return $new;
+    }
+
+    protected function getName(): string
+    {
+        return 'area';
+    }
+}

--- a/src/Tag/Base.php
+++ b/src/Tag/Base.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\VoidTag;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/document-metadata.html#the-base-element
+ */
+final class Base extends VoidTag
+{
+    public function href(?string $url): self
+    {
+        $new = clone $this;
+        $new->attributes['href'] = $url;
+        return $new;
+    }
+
+    public function target(?string $target): self
+    {
+        $new = clone $this;
+        $new->attributes['target'] = $target;
+        return $new;
+    }
+
+    protected function getName(): string
+    {
+        return 'base';
+    }
+}

--- a/src/Tag/Base/ListTag.php
+++ b/src/Tag/Base/ListTag.php
@@ -8,7 +8,7 @@ use Stringable;
 use Yiisoft\Html\Tag\Li;
 
 /**
- * Base for list tags such as "ul" and "ol".
+ * Base for list tags such as "ul", "ol", and "menu".
  */
 abstract class ListTag extends NormalTag
 {

--- a/src/Tag/Bdi.php
+++ b/src/Tag/Bdi.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-bdi-element
+ */
+final class Bdi extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'bdi';
+    }
+}

--- a/src/Tag/Bdo.php
+++ b/src/Tag/Bdo.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-bdo-element
+ */
+final class Bdo extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'bdo';
+    }
+}

--- a/src/Tag/Blockquote.php
+++ b/src/Tag/Blockquote.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/grouping-content.html#the-blockquote-element
+ */
+final class Blockquote extends NormalTag
+{
+    use TagContentTrait;
+
+    public function cite(?string $url): self
+    {
+        $new = clone $this;
+        $new->attributes['cite'] = $url;
+        return $new;
+    }
+
+    protected function getName(): string
+    {
+        return 'blockquote';
+    }
+}

--- a/src/Tag/Canvas.php
+++ b/src/Tag/Canvas.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/canvas.html#the-canvas-element
+ */
+final class Canvas extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'canvas';
+    }
+}

--- a/src/Tag/Cite.php
+++ b/src/Tag/Cite.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-cite-element
+ */
+final class Cite extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'cite';
+    }
+}

--- a/src/Tag/Data.php
+++ b/src/Tag/Data.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-data-element
+ */
+final class Data extends NormalTag
+{
+    use TagContentTrait;
+
+    public function value(?string $value): self
+    {
+        $new = clone $this;
+        $new->attributes['value'] = $value;
+        return $new;
+    }
+
+    protected function getName(): string
+    {
+        return 'data';
+    }
+}

--- a/src/Tag/Dd.php
+++ b/src/Tag/Dd.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/grouping-content.html#the-dd-element
+ */
+final class Dd extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'dd';
+    }
+}

--- a/src/Tag/Del.php
+++ b/src/Tag/Del.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/edits.html#the-del-element
+ */
+final class Del extends NormalTag
+{
+    use TagContentTrait;
+
+    public function cite(?string $url): self
+    {
+        $new = clone $this;
+        $new->attributes['cite'] = $url;
+        return $new;
+    }
+
+    public function datetime(?string $datetime): self
+    {
+        $new = clone $this;
+        $new->attributes['datetime'] = $datetime;
+        return $new;
+    }
+
+    protected function getName(): string
+    {
+        return 'del';
+    }
+}

--- a/src/Tag/Details.php
+++ b/src/Tag/Details.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element
+ */
+final class Details extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'details';
+    }
+}

--- a/src/Tag/Dfn.php
+++ b/src/Tag/Dfn.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-dfn-element
+ */
+final class Dfn extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'dfn';
+    }
+}

--- a/src/Tag/Dialog.php
+++ b/src/Tag/Dialog.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element
+ */
+final class Dialog extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'dialog';
+    }
+}

--- a/src/Tag/Dl.php
+++ b/src/Tag/Dl.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element
+ */
+final class Dl extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'dl';
+    }
+}

--- a/src/Tag/Dt.php
+++ b/src/Tag/Dt.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/grouping-content.html#the-dt-element
+ */
+final class Dt extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'dt';
+    }
+}

--- a/src/Tag/Embed.php
+++ b/src/Tag/Embed.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\VoidTag;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/embedded-content.html#the-embed-element
+ */
+final class Embed extends VoidTag
+{
+    public function src(?string $url): self
+    {
+        $new = clone $this;
+        $new->attributes['src'] = $url;
+        return $new;
+    }
+
+    public function type(?string $type): self
+    {
+        $new = clone $this;
+        $new->attributes['type'] = $type;
+        return $new;
+    }
+
+    public function width(int|string|null $width): self
+    {
+        $new = clone $this;
+        $new->attributes['width'] = $width;
+        return $new;
+    }
+
+    public function height(int|string|null $height): self
+    {
+        $new = clone $this;
+        $new->attributes['height'] = $height;
+        return $new;
+    }
+
+    protected function getName(): string
+    {
+        return 'embed';
+    }
+}

--- a/src/Tag/Figcaption.php
+++ b/src/Tag/Figcaption.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/grouping-content.html#the-figcaption-element
+ */
+final class Figcaption extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'figcaption';
+    }
+}

--- a/src/Tag/Figure.php
+++ b/src/Tag/Figure.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/grouping-content.html#the-figure-element
+ */
+final class Figure extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'figure';
+    }
+}

--- a/src/Tag/Head.php
+++ b/src/Tag/Head.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/semantics.html#the-head-element
+ */
+final class Head extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'head';
+    }
+}

--- a/src/Tag/Iframe.php
+++ b/src/Tag/Iframe.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element
+ */
+final class Iframe extends NormalTag
+{
+    use TagContentTrait;
+
+    public function src(?string $url): self
+    {
+        $new = clone $this;
+        $new->attributes['src'] = $url;
+        return $new;
+    }
+
+    protected function getName(): string
+    {
+        return 'iframe';
+    }
+}

--- a/src/Tag/Iframe.php
+++ b/src/Tag/Iframe.php
@@ -5,15 +5,12 @@ declare(strict_types=1);
 namespace Yiisoft\Html\Tag;
 
 use Yiisoft\Html\Tag\Base\NormalTag;
-use Yiisoft\Html\Tag\Base\TagContentTrait;
 
 /**
  * @link https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element
  */
 final class Iframe extends NormalTag
 {
-    use TagContentTrait;
-
     public function src(?string $url): self
     {
         $new = clone $this;
@@ -24,5 +21,10 @@ final class Iframe extends NormalTag
     protected function getName(): string
     {
         return 'iframe';
+    }
+
+    protected function generateContent(): string
+    {
+        return '';
     }
 }

--- a/src/Tag/Ins.php
+++ b/src/Tag/Ins.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/edits.html#the-ins-element
+ */
+final class Ins extends NormalTag
+{
+    use TagContentTrait;
+
+    public function cite(?string $url): self
+    {
+        $new = clone $this;
+        $new->attributes['cite'] = $url;
+        return $new;
+    }
+
+    public function datetime(?string $datetime): self
+    {
+        $new = clone $this;
+        $new->attributes['datetime'] = $datetime;
+        return $new;
+    }
+
+    protected function getName(): string
+    {
+        return 'ins';
+    }
+}

--- a/src/Tag/Kbd.php
+++ b/src/Tag/Kbd.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-kbd-element
+ */
+final class Kbd extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'kbd';
+    }
+}

--- a/src/Tag/Main.php
+++ b/src/Tag/Main.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element
+ */
+final class Main extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'main';
+    }
+}

--- a/src/Tag/Map.php
+++ b/src/Tag/Map.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/image-maps.html#the-map-element
+ */
+final class Map extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'map';
+    }
+}

--- a/src/Tag/Mark.php
+++ b/src/Tag/Mark.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-mark-element
+ */
+final class Mark extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'mark';
+    }
+}

--- a/src/Tag/Menu.php
+++ b/src/Tag/Menu.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\ListTag;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/grouping-content.html#the-menu-element
+ */
+final class Menu extends ListTag
+{
+    protected function getName(): string
+    {
+        return 'menu';
+    }
+}

--- a/src/Tag/Meter.php
+++ b/src/Tag/Meter.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/form-elements.html#the-meter-element
+ */
+final class Meter extends NormalTag
+{
+    use TagContentTrait;
+
+    public function min(float|int|null $value): self
+    {
+        $new = clone $this;
+        $new->attributes['min'] = $value;
+        return $new;
+    }
+
+    public function max(float|int|null $value): self
+    {
+        $new = clone $this;
+        $new->attributes['max'] = $value;
+        return $new;
+    }
+
+    public function value(float|int|null $value): self
+    {
+        $new = clone $this;
+        $new->attributes['value'] = $value;
+        return $new;
+    }
+
+    public function low(float|int|null $value): self
+    {
+        $new = clone $this;
+        $new->attributes['low'] = $value;
+        return $new;
+    }
+
+    public function high(float|int|null $value): self
+    {
+        $new = clone $this;
+        $new->attributes['high'] = $value;
+        return $new;
+    }
+
+    public function optimum(float|int|null $value): self
+    {
+        $new = clone $this;
+        $new->attributes['optimum'] = $value;
+        return $new;
+    }
+
+    protected function getName(): string
+    {
+        return 'meter';
+    }
+}

--- a/src/Tag/ObjectTag.php
+++ b/src/Tag/ObjectTag.php
@@ -10,7 +10,7 @@ use Yiisoft\Html\Tag\Base\TagContentTrait;
 /**
  * @link https://html.spec.whatwg.org/multipage/embedded-content.html#the-object-element
  */
-final class Object_ extends NormalTag
+final class ObjectTag extends NormalTag
 {
     use TagContentTrait;
 

--- a/src/Tag/Object_.php
+++ b/src/Tag/Object_.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/embedded-content.html#the-object-element
+ */
+final class Object_ extends NormalTag
+{
+    use TagContentTrait;
+
+    public function data(?string $url): self
+    {
+        $new = clone $this;
+        $new->attributes['data'] = $url;
+        return $new;
+    }
+
+    public function form(?string $id): self
+    {
+        $new = clone $this;
+        $new->attributes['form'] = $id;
+        return $new;
+    }
+
+    public function name(?string $name): self
+    {
+        $new = clone $this;
+        $new->attributes['name'] = $name;
+        return $new;
+    }
+
+    public function type(?string $type): self
+    {
+        $new = clone $this;
+        $new->attributes['type'] = $type;
+        return $new;
+    }
+
+    public function width(int|string|null $width): self
+    {
+        $new = clone $this;
+        $new->attributes['width'] = $width;
+        return $new;
+    }
+
+    public function height(int|string|null $height): self
+    {
+        $new = clone $this;
+        $new->attributes['height'] = $height;
+        return $new;
+    }
+
+    protected function getName(): string
+    {
+        return 'object';
+    }
+}

--- a/src/Tag/Output.php
+++ b/src/Tag/Output.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/form-elements.html#the-output-element
+ */
+final class Output extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'output';
+    }
+}

--- a/src/Tag/Progress.php
+++ b/src/Tag/Progress.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/form-elements.html#the-progress-element
+ */
+final class Progress extends NormalTag
+{
+    use TagContentTrait;
+
+    public function max(float|int|null $value): self
+    {
+        $new = clone $this;
+        $new->attributes['max'] = $value;
+        return $new;
+    }
+
+    public function value(float|int|null $value): self
+    {
+        $new = clone $this;
+        $new->attributes['value'] = $value;
+        return $new;
+    }
+
+    protected function getName(): string
+    {
+        return 'progress';
+    }
+}

--- a/src/Tag/Q.php
+++ b/src/Tag/Q.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-q-element
+ */
+final class Q extends NormalTag
+{
+    use TagContentTrait;
+
+    public function cite(?string $url): self
+    {
+        $new = clone $this;
+        $new->attributes['cite'] = $url;
+        return $new;
+    }
+
+    protected function getName(): string
+    {
+        return 'q';
+    }
+}

--- a/src/Tag/Rp.php
+++ b/src/Tag/Rp.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-rp-element
+ */
+final class Rp extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'rp';
+    }
+}

--- a/src/Tag/Rt.php
+++ b/src/Tag/Rt.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-rt-element
+ */
+final class Rt extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'rt';
+    }
+}

--- a/src/Tag/Ruby.php
+++ b/src/Tag/Ruby.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-ruby-element
+ */
+final class Ruby extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'ruby';
+    }
+}

--- a/src/Tag/S.php
+++ b/src/Tag/S.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-s-element
+ */
+final class S extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 's';
+    }
+}

--- a/src/Tag/Samp.php
+++ b/src/Tag/Samp.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-samp-element
+ */
+final class Samp extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'samp';
+    }
+}

--- a/src/Tag/Search.php
+++ b/src/Tag/Search.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/grouping-content.html#the-search-element
+ */
+final class Search extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'search';
+    }
+}

--- a/src/Tag/Slot.php
+++ b/src/Tag/Slot.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element
+ */
+final class Slot extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'slot';
+    }
+}

--- a/src/Tag/Sub.php
+++ b/src/Tag/Sub.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-sub-and-sup-elements
+ */
+final class Sub extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'sub';
+    }
+}

--- a/src/Tag/Summary.php
+++ b/src/Tag/Summary.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/interactive-elements.html#the-summary-element
+ */
+final class Summary extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'summary';
+    }
+}

--- a/src/Tag/Sup.php
+++ b/src/Tag/Sup.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-sub-and-sup-elements
+ */
+final class Sup extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'sup';
+    }
+}

--- a/src/Tag/Template.php
+++ b/src/Tag/Template.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/scripting.html#the-template-element
+ */
+final class Template extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'template';
+    }
+}

--- a/src/Tag/Time.php
+++ b/src/Tag/Time.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-time-element
+ */
+final class Time extends NormalTag
+{
+    use TagContentTrait;
+
+    public function datetime(?string $datetime): self
+    {
+        $new = clone $this;
+        $new->attributes['datetime'] = $datetime;
+        return $new;
+    }
+
+    protected function getName(): string
+    {
+        return 'time';
+    }
+}

--- a/src/Tag/U.php
+++ b/src/Tag/U.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-u-element
+ */
+final class U extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'u';
+    }
+}

--- a/src/Tag/VarTag.php
+++ b/src/Tag/VarTag.php
@@ -10,7 +10,7 @@ use Yiisoft\Html\Tag\Base\TagContentTrait;
 /**
  * @link https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-var-element
  */
-final class Var_ extends NormalTag
+final class VarTag extends NormalTag
 {
     use TagContentTrait;
 

--- a/src/Tag/Var_.php
+++ b/src/Tag/Var_.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\NormalTag;
+use Yiisoft\Html\Tag\Base\TagContentTrait;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-var-element
+ */
+final class Var_ extends NormalTag
+{
+    use TagContentTrait;
+
+    protected function getName(): string
+    {
+        return 'var';
+    }
+}

--- a/src/Tag/Wbr.php
+++ b/src/Tag/Wbr.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tag;
+
+use Yiisoft\Html\Tag\Base\VoidTag;
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-wbr-element
+ */
+final class Wbr extends VoidTag
+{
+    protected function getName(): string
+    {
+        return 'wbr';
+    }
+}

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -1414,4 +1414,542 @@ final class HtmlTest extends TestCase
             Html::address('Street 111, Mount View Town.', ['class' => 'red'])->render(),
         );
     }
+
+    public function testAbbr(): void
+    {
+        $this->assertSame('<abbr></abbr>', Html::abbr()->render());
+        $this->assertSame(
+            '<abbr>HTML</abbr>',
+            Html::abbr('HTML')->render(),
+        );
+        $this->assertSame(
+            '<abbr class="red">HTML</abbr>',
+            Html::abbr('HTML', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testBdi(): void
+    {
+        $this->assertSame('<bdi></bdi>', Html::bdi()->render());
+        $this->assertSame(
+            '<bdi>text</bdi>',
+            Html::bdi('text')->render(),
+        );
+        $this->assertSame(
+            '<bdi class="red">text</bdi>',
+            Html::bdi('text', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testBdo(): void
+    {
+        $this->assertSame('<bdo></bdo>', Html::bdo()->render());
+        $this->assertSame(
+            '<bdo>text</bdo>',
+            Html::bdo('text')->render(),
+        );
+        $this->assertSame(
+            '<bdo class="red">text</bdo>',
+            Html::bdo('text', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testBlockquote(): void
+    {
+        $this->assertSame('<blockquote></blockquote>', Html::blockquote()->render());
+        $this->assertSame(
+            '<blockquote>Quote</blockquote>',
+            Html::blockquote('Quote')->render(),
+        );
+        $this->assertSame(
+            '<blockquote class="red">Quote</blockquote>',
+            Html::blockquote('Quote', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testCanvas(): void
+    {
+        $this->assertSame('<canvas></canvas>', Html::canvas()->render());
+        $this->assertSame(
+            '<canvas>Fallback</canvas>',
+            Html::canvas('Fallback')->render(),
+        );
+        $this->assertSame(
+            '<canvas class="red">Fallback</canvas>',
+            Html::canvas('Fallback', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testCite(): void
+    {
+        $this->assertSame('<cite></cite>', Html::cite()->render());
+        $this->assertSame(
+            '<cite>Source</cite>',
+            Html::cite('Source')->render(),
+        );
+        $this->assertSame(
+            '<cite class="red">Source</cite>',
+            Html::cite('Source', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testData(): void
+    {
+        $this->assertSame('<data></data>', Html::data()->render());
+        $this->assertSame(
+            '<data>Value</data>',
+            Html::data('Value')->render(),
+        );
+        $this->assertSame(
+            '<data class="red">Value</data>',
+            Html::data('Value', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testDd(): void
+    {
+        $this->assertSame('<dd></dd>', Html::dd()->render());
+        $this->assertSame(
+            '<dd>Definition</dd>',
+            Html::dd('Definition')->render(),
+        );
+        $this->assertSame(
+            '<dd class="red">Definition</dd>',
+            Html::dd('Definition', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testDel(): void
+    {
+        $this->assertSame('<del></del>', Html::del()->render());
+        $this->assertSame(
+            '<del>Removed</del>',
+            Html::del('Removed')->render(),
+        );
+        $this->assertSame(
+            '<del class="red">Removed</del>',
+            Html::del('Removed', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testDetails(): void
+    {
+        $this->assertSame('<details></details>', Html::details()->render());
+        $this->assertSame(
+            '<details>Content</details>',
+            Html::details('Content')->render(),
+        );
+        $this->assertSame(
+            '<details class="red">Content</details>',
+            Html::details('Content', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testDfn(): void
+    {
+        $this->assertSame('<dfn></dfn>', Html::dfn()->render());
+        $this->assertSame(
+            '<dfn>Term</dfn>',
+            Html::dfn('Term')->render(),
+        );
+        $this->assertSame(
+            '<dfn class="red">Term</dfn>',
+            Html::dfn('Term', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testDialog(): void
+    {
+        $this->assertSame('<dialog></dialog>', Html::dialog()->render());
+        $this->assertSame(
+            '<dialog>Content</dialog>',
+            Html::dialog('Content')->render(),
+        );
+        $this->assertSame(
+            '<dialog class="red">Content</dialog>',
+            Html::dialog('Content', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testDl(): void
+    {
+        $this->assertSame('<dl></dl>', Html::dl()->render());
+        $this->assertSame(
+            '<dl>List</dl>',
+            Html::dl('List')->render(),
+        );
+        $this->assertSame(
+            '<dl class="red">List</dl>',
+            Html::dl('List', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testDt(): void
+    {
+        $this->assertSame('<dt></dt>', Html::dt()->render());
+        $this->assertSame(
+            '<dt>Term</dt>',
+            Html::dt('Term')->render(),
+        );
+        $this->assertSame(
+            '<dt class="red">Term</dt>',
+            Html::dt('Term', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testFigcaption(): void
+    {
+        $this->assertSame('<figcaption></figcaption>', Html::figcaption()->render());
+        $this->assertSame(
+            '<figcaption>Caption</figcaption>',
+            Html::figcaption('Caption')->render(),
+        );
+        $this->assertSame(
+            '<figcaption class="red">Caption</figcaption>',
+            Html::figcaption('Caption', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testFigure(): void
+    {
+        $this->assertSame('<figure></figure>', Html::figure()->render());
+        $this->assertSame(
+            '<figure>Content</figure>',
+            Html::figure('Content')->render(),
+        );
+        $this->assertSame(
+            '<figure class="red">Content</figure>',
+            Html::figure('Content', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testHead(): void
+    {
+        $this->assertSame('<head></head>', Html::head()->render());
+        $this->assertSame(
+            '<head>Meta</head>',
+            Html::head('Meta')->render(),
+        );
+        $this->assertSame(
+            '<head class="red">Meta</head>',
+            Html::head('Meta', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testIframe(): void
+    {
+        $this->assertSame('<iframe></iframe>', Html::iframe()->render());
+        $this->assertSame(
+            '<iframe>Fallback</iframe>',
+            Html::iframe('Fallback')->render(),
+        );
+    }
+
+    public function testIns(): void
+    {
+        $this->assertSame('<ins></ins>', Html::ins()->render());
+        $this->assertSame(
+            '<ins>Added</ins>',
+            Html::ins('Added')->render(),
+        );
+        $this->assertSame(
+            '<ins class="red">Added</ins>',
+            Html::ins('Added', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testKbd(): void
+    {
+        $this->assertSame('<kbd></kbd>', Html::kbd()->render());
+        $this->assertSame(
+            '<kbd>Ctrl+C</kbd>',
+            Html::kbd('Ctrl+C')->render(),
+        );
+        $this->assertSame(
+            '<kbd class="red">Ctrl+C</kbd>',
+            Html::kbd('Ctrl+C', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testMain(): void
+    {
+        $this->assertSame('<main></main>', Html::main()->render());
+        $this->assertSame(
+            '<main>Content</main>',
+            Html::main('Content')->render(),
+        );
+        $this->assertSame(
+            '<main class="red">Content</main>',
+            Html::main('Content', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testMap(): void
+    {
+        $this->assertSame('<map></map>', Html::map()->render());
+        $this->assertSame(
+            '<map>Area</map>',
+            Html::map('Area')->render(),
+        );
+        $this->assertSame(
+            '<map class="red">Area</map>',
+            Html::map('Area', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testMark(): void
+    {
+        $this->assertSame('<mark></mark>', Html::mark()->render());
+        $this->assertSame(
+            '<mark>Highlight</mark>',
+            Html::mark('Highlight')->render(),
+        );
+        $this->assertSame(
+            '<mark class="red">Highlight</mark>',
+            Html::mark('Highlight', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testMenu(): void
+    {
+        $this->assertSame('<menu></menu>', Html::menu()->render());
+        $this->assertSame(
+            '<menu class="red"></menu>',
+            Html::menu(['class' => 'red'])->render(),
+        );
+    }
+
+    public function testMeter(): void
+    {
+        $this->assertSame('<meter></meter>', Html::meter()->render());
+        $this->assertSame(
+            '<meter>Value</meter>',
+            Html::meter('Value')->render(),
+        );
+        $this->assertSame(
+            '<meter class="red">Value</meter>',
+            Html::meter('Value', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testOutput(): void
+    {
+        $this->assertSame('<output></output>', Html::output()->render());
+        $this->assertSame(
+            '<output>Result</output>',
+            Html::output('Result')->render(),
+        );
+        $this->assertSame(
+            '<output class="red">Result</output>',
+            Html::output('Result', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testProgress(): void
+    {
+        $this->assertSame('<progress></progress>', Html::progress()->render());
+        $this->assertSame(
+            '<progress>Loading</progress>',
+            Html::progress('Loading')->render(),
+        );
+        $this->assertSame(
+            '<progress class="red">Loading</progress>',
+            Html::progress('Loading', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testQ(): void
+    {
+        $this->assertSame('<q></q>', Html::q()->render());
+        $this->assertSame(
+            '<q>Quote</q>',
+            Html::q('Quote')->render(),
+        );
+        $this->assertSame(
+            '<q class="red">Quote</q>',
+            Html::q('Quote', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testRp(): void
+    {
+        $this->assertSame('<rp></rp>', Html::rp()->render());
+        $this->assertSame(
+            '<rp>Fallback</rp>',
+            Html::rp('Fallback')->render(),
+        );
+        $this->assertSame(
+            '<rp class="red">Fallback</rp>',
+            Html::rp('Fallback', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testRt(): void
+    {
+        $this->assertSame('<rt></rt>', Html::rt()->render());
+        $this->assertSame(
+            '<rt>Annotation</rt>',
+            Html::rt('Annotation')->render(),
+        );
+        $this->assertSame(
+            '<rt class="red">Annotation</rt>',
+            Html::rt('Annotation', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testRuby(): void
+    {
+        $this->assertSame('<ruby></ruby>', Html::ruby()->render());
+        $this->assertSame(
+            '<ruby>Base</ruby>',
+            Html::ruby('Base')->render(),
+        );
+        $this->assertSame(
+            '<ruby class="red">Base</ruby>',
+            Html::ruby('Base', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testS(): void
+    {
+        $this->assertSame('<s></s>', Html::s()->render());
+        $this->assertSame(
+            '<s>Strikethrough</s>',
+            Html::s('Strikethrough')->render(),
+        );
+        $this->assertSame(
+            '<s class="red">Strikethrough</s>',
+            Html::s('Strikethrough', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testSamp(): void
+    {
+        $this->assertSame('<samp></samp>', Html::samp()->render());
+        $this->assertSame(
+            '<samp>Output</samp>',
+            Html::samp('Output')->render(),
+        );
+        $this->assertSame(
+            '<samp class="red">Output</samp>',
+            Html::samp('Output', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testSearch(): void
+    {
+        $this->assertSame('<search></search>', Html::search()->render());
+        $this->assertSame(
+            '<search>Results</search>',
+            Html::search('Results')->render(),
+        );
+        $this->assertSame(
+            '<search class="red">Results</search>',
+            Html::search('Results', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testSlot(): void
+    {
+        $this->assertSame('<slot></slot>', Html::slot()->render());
+        $this->assertSame(
+            '<slot>Fallback</slot>',
+            Html::slot('Fallback')->render(),
+        );
+        $this->assertSame(
+            '<slot class="red">Fallback</slot>',
+            Html::slot('Fallback', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testSub(): void
+    {
+        $this->assertSame('<sub></sub>', Html::sub()->render());
+        $this->assertSame(
+            '<sub>Subscript</sub>',
+            Html::sub('Subscript')->render(),
+        );
+        $this->assertSame(
+            '<sub class="red">Subscript</sub>',
+            Html::sub('Subscript', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testSummary(): void
+    {
+        $this->assertSame('<summary></summary>', Html::summary()->render());
+        $this->assertSame(
+            '<summary>Summary</summary>',
+            Html::summary('Summary')->render(),
+        );
+        $this->assertSame(
+            '<summary class="red">Summary</summary>',
+            Html::summary('Summary', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testSup(): void
+    {
+        $this->assertSame('<sup></sup>', Html::sup()->render());
+        $this->assertSame(
+            '<sup>Superscript</sup>',
+            Html::sup('Superscript')->render(),
+        );
+        $this->assertSame(
+            '<sup class="red">Superscript</sup>',
+            Html::sup('Superscript', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testTemplate(): void
+    {
+        $this->assertSame('<template></template>', Html::template()->render());
+        $this->assertSame(
+            '<template>Content</template>',
+            Html::template('Content')->render(),
+        );
+        $this->assertSame(
+            '<template class="red">Content</template>',
+            Html::template('Content', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testTime(): void
+    {
+        $this->assertSame('<time></time>', Html::time()->render());
+        $this->assertSame(
+            '<time>2024</time>',
+            Html::time('2024')->render(),
+        );
+        $this->assertSame(
+            '<time class="red">2024</time>',
+            Html::time('2024', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testU(): void
+    {
+        $this->assertSame('<u></u>', Html::u()->render());
+        $this->assertSame(
+            '<u>Underline</u>',
+            Html::u('Underline')->render(),
+        );
+        $this->assertSame(
+            '<u class="red">Underline</u>',
+            Html::u('Underline', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testVar(): void
+    {
+        $this->assertSame('<var></var>', Html::var()->render());
+        $this->assertSame(
+            '<var>x</var>',
+            Html::var('x')->render(),
+        );
+        $this->assertSame(
+            '<var class="red">x</var>',
+            Html::var('x', ['class' => 'red'])->render(),
+        );
+    }
 }

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -1428,6 +1428,32 @@ final class HtmlTest extends TestCase
         );
     }
 
+    public function testArea(): void
+    {
+        $this->assertSame('<area>', Html::area()->render());
+        $this->assertSame(
+            '<area alt="Example">',
+            Html::area('Example')->render(),
+        );
+        $this->assertSame(
+            '<area class="red" alt="Example">',
+            Html::area('Example', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testBase(): void
+    {
+        $this->assertSame('<base>', Html::base()->render());
+        $this->assertSame(
+            '<base href="https://example.com">',
+            Html::base('https://example.com')->render(),
+        );
+        $this->assertSame(
+            '<base class="red" href="https://example.com">',
+            Html::base('https://example.com', ['class' => 'red'])->render(),
+        );
+    }
+
     public function testBdi(): void
     {
         $this->assertSame('<bdi></bdi>', Html::bdi()->render());
@@ -1597,6 +1623,19 @@ final class HtmlTest extends TestCase
         );
     }
 
+    public function testEmbed(): void
+    {
+        $this->assertSame('<embed>', Html::embed()->render());
+        $this->assertSame(
+            '<embed src="https://example.com/video.mp4">',
+            Html::embed('https://example.com/video.mp4')->render(),
+        );
+        $this->assertSame(
+            '<embed class="red" src="https://example.com/video.mp4">',
+            Html::embed('https://example.com/video.mp4', ['class' => 'red'])->render(),
+        );
+    }
+
     public function testFigcaption(): void
     {
         $this->assertSame('<figcaption></figcaption>', Html::figcaption()->render());
@@ -1733,6 +1772,19 @@ final class HtmlTest extends TestCase
         $this->assertSame(
             '<meter class="red">Value</meter>',
             Html::meter('Value', ['class' => 'red'])->render(),
+        );
+    }
+
+    public function testObject(): void
+    {
+        $this->assertSame('<object></object>', Html::object()->render());
+        $this->assertSame(
+            '<object>Applet</object>',
+            Html::object('Applet')->render(),
+        );
+        $this->assertSame(
+            '<object class="red">Applet</object>',
+            Html::object('Applet', ['class' => 'red'])->render(),
         );
     }
 
@@ -1955,5 +2007,10 @@ final class HtmlTest extends TestCase
             '<var class="red">x</var>',
             Html::var('x', ['class' => 'red'])->render(),
         );
+    }
+
+    public function testWbr(): void
+    {
+        $this->assertSame('<wbr>', Html::wbr()->render());
     }
 }

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -1679,12 +1679,12 @@ final class HtmlTest extends TestCase
     {
         $this->assertSame('<iframe></iframe>', Html::iframe()->render());
         $this->assertSame(
-            '<iframe>Fallback</iframe>',
-            Html::iframe('Fallback')->render(),
+            '<iframe src="https://example.com"></iframe>',
+            Html::iframe('https://example.com')->render(),
         );
         $this->assertSame(
-            '<iframe class="red">Fallback</iframe>',
-            Html::iframe('Fallback', ['class' => 'red'])->render(),
+            '<iframe class="red" src="https://example.com"></iframe>',
+            Html::iframe('https://example.com', ['class' => 'red'])->render(),
         );
     }
 

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -1643,6 +1643,10 @@ final class HtmlTest extends TestCase
             '<iframe>Fallback</iframe>',
             Html::iframe('Fallback')->render(),
         );
+        $this->assertSame(
+            '<iframe class="red">Fallback</iframe>',
+            Html::iframe('Fallback', ['class' => 'red'])->render(),
+        );
     }
 
     public function testIns(): void

--- a/tests/Tag/AbbrTest.php
+++ b/tests/Tag/AbbrTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Abbr;
+
+final class AbbrTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<abbr class="red">Hello</abbr>',
+            (string) (new Abbr())
+                ->class('red')
+                ->content('Hello'),
+        );
+    }
+}

--- a/tests/Tag/AreaTest.php
+++ b/tests/Tag/AreaTest.php
@@ -57,14 +57,6 @@ final class AreaTest extends TestCase
         );
     }
 
-    public function testMedia(): void
-    {
-        $this->assertSame(
-            '<area media="screen">',
-            (string) (new Area())->media('screen'),
-        );
-    }
-
     public function testReferrerpolicy(): void
     {
         $this->assertSame(
@@ -103,5 +95,20 @@ final class AreaTest extends TestCase
             '<area type="text/html">',
             (string) (new Area())->type('text/html'),
         );
+    }
+
+    public function testImmutability(): void
+    {
+        $area = new Area();
+        $this->assertNotSame($area, $area->alt(null));
+        $this->assertNotSame($area, $area->coords(null));
+        $this->assertNotSame($area, $area->download(null));
+        $this->assertNotSame($area, $area->href(null));
+        $this->assertNotSame($area, $area->hreflang(null));
+        $this->assertNotSame($area, $area->referrerpolicy(null));
+        $this->assertNotSame($area, $area->rel(null));
+        $this->assertNotSame($area, $area->shape(null));
+        $this->assertNotSame($area, $area->target(null));
+        $this->assertNotSame($area, $area->type(null));
     }
 }

--- a/tests/Tag/AreaTest.php
+++ b/tests/Tag/AreaTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Area;
+
+final class AreaTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<area>',
+            (string) new Area(),
+        );
+    }
+
+    public function testAlt(): void
+    {
+        $this->assertSame(
+            '<area alt="Example">',
+            (string) (new Area())->alt('Example'),
+        );
+    }
+
+    public function testCoords(): void
+    {
+        $this->assertSame(
+            '<area coords="10,20,30,40">',
+            (string) (new Area())->coords('10,20,30,40'),
+        );
+    }
+
+    public function testDownload(): void
+    {
+        $this->assertSame(
+            '<area download="file.txt">',
+            (string) (new Area())->download('file.txt'),
+        );
+    }
+
+    public function testHref(): void
+    {
+        $this->assertSame(
+            '<area href="https://example.com">',
+            (string) (new Area())->href('https://example.com'),
+        );
+    }
+
+    public function testHreflang(): void
+    {
+        $this->assertSame(
+            '<area hreflang="en">',
+            (string) (new Area())->hreflang('en'),
+        );
+    }
+
+    public function testMedia(): void
+    {
+        $this->assertSame(
+            '<area media="screen">',
+            (string) (new Area())->media('screen'),
+        );
+    }
+
+    public function testReferrerpolicy(): void
+    {
+        $this->assertSame(
+            '<area referrerpolicy="no-referrer">',
+            (string) (new Area())->referrerpolicy('no-referrer'),
+        );
+    }
+
+    public function testRel(): void
+    {
+        $this->assertSame(
+            '<area rel="nofollow">',
+            (string) (new Area())->rel('nofollow'),
+        );
+    }
+
+    public function testShape(): void
+    {
+        $this->assertSame(
+            '<area shape="rect">',
+            (string) (new Area())->shape('rect'),
+        );
+    }
+
+    public function testTarget(): void
+    {
+        $this->assertSame(
+            '<area target="_blank">',
+            (string) (new Area())->target('_blank'),
+        );
+    }
+
+    public function testType(): void
+    {
+        $this->assertSame(
+            '<area type="text/html">',
+            (string) (new Area())->type('text/html'),
+        );
+    }
+}

--- a/tests/Tag/BaseTest.php
+++ b/tests/Tag/BaseTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Base;
+
+final class BaseTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<base>',
+            (string) new Base(),
+        );
+    }
+
+    public function testHref(): void
+    {
+        $this->assertSame(
+            '<base href="https://example.com">',
+            (string) (new Base())->href('https://example.com'),
+        );
+    }
+
+    public function testTarget(): void
+    {
+        $this->assertSame(
+            '<base target="_blank">',
+            (string) (new Base())->target('_blank'),
+        );
+    }
+}

--- a/tests/Tag/BaseTest.php
+++ b/tests/Tag/BaseTest.php
@@ -32,4 +32,11 @@ final class BaseTest extends TestCase
             (string) (new Base())->target('_blank'),
         );
     }
+
+    public function testImmutability(): void
+    {
+        $base = new Base();
+        $this->assertNotSame($base, $base->href(null));
+        $this->assertNotSame($base, $base->target(null));
+    }
 }

--- a/tests/Tag/BdiTest.php
+++ b/tests/Tag/BdiTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Bdi;
+
+final class BdiTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<bdi class="red">Hello</bdi>',
+            (string) (new Bdi())
+                ->class('red')
+                ->content('Hello'),
+        );
+    }
+}

--- a/tests/Tag/BdoTest.php
+++ b/tests/Tag/BdoTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Bdo;
+
+final class BdoTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<bdo class="red">Hello</bdo>',
+            (string) (new Bdo())
+                ->class('red')
+                ->content('Hello'),
+        );
+    }
+}

--- a/tests/Tag/BlockquoteTest.php
+++ b/tests/Tag/BlockquoteTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Blockquote;
+use Yiisoft\Html\Tag\P;
+
+final class BlockquoteTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<blockquote><p>Quote</p></blockquote>',
+            (string) (new Blockquote())
+                ->content(
+                    (new P())->content('Quote'),
+                ),
+        );
+    }
+
+    public function testCite(): void
+    {
+        $this->assertSame(
+            '<blockquote cite="https://example.com"><p>Quote</p></blockquote>',
+            (string) (new Blockquote())
+                ->cite('https://example.com')
+                ->content(
+                    (new P())->content('Quote'),
+                ),
+        );
+    }
+}

--- a/tests/Tag/BlockquoteTest.php
+++ b/tests/Tag/BlockquoteTest.php
@@ -32,4 +32,10 @@ final class BlockquoteTest extends TestCase
                 ),
         );
     }
+
+    public function testImmutability(): void
+    {
+        $tag = new Blockquote();
+        $this->assertNotSame($tag, $tag->cite(null));
+    }
 }

--- a/tests/Tag/CanvasTest.php
+++ b/tests/Tag/CanvasTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Canvas;
+
+final class CanvasTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<canvas class="red">Hello</canvas>',
+            (string) (new Canvas())
+                ->class('red')
+                ->content('Hello'),
+        );
+    }
+}

--- a/tests/Tag/CiteTest.php
+++ b/tests/Tag/CiteTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Cite;
+
+final class CiteTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<cite class="red">Hello</cite>',
+            (string) (new Cite())
+                ->class('red')
+                ->content('Hello'),
+        );
+    }
+}

--- a/tests/Tag/DataTest.php
+++ b/tests/Tag/DataTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Data;
+
+final class DataTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<data class="red">Hello</data>',
+            (string) (new Data())
+                ->class('red')
+                ->content('Hello'),
+        );
+    }
+
+    public function testValue(): void
+    {
+        $this->assertSame(
+            '<data value="42">Hello</data>',
+            (string) (new Data())
+                ->value('42')
+                ->content('Hello'),
+        );
+    }
+}

--- a/tests/Tag/DataTest.php
+++ b/tests/Tag/DataTest.php
@@ -28,4 +28,10 @@ final class DataTest extends TestCase
                 ->content('Hello'),
         );
     }
+
+    public function testImmutability(): void
+    {
+        $tag = new Data();
+        $this->assertNotSame($tag, $tag->value(null));
+    }
 }

--- a/tests/Tag/DdTest.php
+++ b/tests/Tag/DdTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Dd;
+
+final class DdTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<dd class="red">Hello</dd>',
+            (string) (new Dd())
+                ->class('red')
+                ->content('Hello'),
+        );
+    }
+}

--- a/tests/Tag/DelTest.php
+++ b/tests/Tag/DelTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Del;
+use Yiisoft\Html\Tag\P;
+
+final class DelTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<del><p>Removed</p></del>',
+            (string) (new Del())
+                ->content(
+                    (new P())->content('Removed'),
+                ),
+        );
+    }
+
+    public function testCite(): void
+    {
+        $this->assertSame(
+            '<del cite="https://example.com"><p>Removed</p></del>',
+            (string) (new Del())
+                ->cite('https://example.com')
+                ->content(
+                    (new P())->content('Removed'),
+                ),
+        );
+    }
+
+    public function testDatetime(): void
+    {
+        $this->assertSame(
+            '<del datetime="2024-01-01"><p>Removed</p></del>',
+            (string) (new Del())
+                ->datetime('2024-01-01')
+                ->content(
+                    (new P())->content('Removed'),
+                ),
+        );
+    }
+}

--- a/tests/Tag/DelTest.php
+++ b/tests/Tag/DelTest.php
@@ -44,4 +44,11 @@ final class DelTest extends TestCase
                 ),
         );
     }
+
+    public function testImmutability(): void
+    {
+        $tag = new Del();
+        $this->assertNotSame($tag, $tag->cite(null));
+        $this->assertNotSame($tag, $tag->datetime(null));
+    }
 }

--- a/tests/Tag/DetailsTest.php
+++ b/tests/Tag/DetailsTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Details;
+use Yiisoft\Html\Tag\P;
+use Yiisoft\Html\Tag\Summary;
+
+final class DetailsTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<details><summary>Info</summary><p>Details content</p></details>',
+            (string) (new Details())
+                ->content(
+                    (new Summary())->content('Info')
+                    . (new P())->content('Details content'),
+                )
+                ->encode(false),
+        );
+    }
+}

--- a/tests/Tag/DfnTest.php
+++ b/tests/Tag/DfnTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Dfn;
+
+final class DfnTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<dfn class="red">Hello</dfn>',
+            (string) (new Dfn())
+                ->class('red')
+                ->content('Hello'),
+        );
+    }
+}

--- a/tests/Tag/DialogTest.php
+++ b/tests/Tag/DialogTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Dialog;
+use Yiisoft\Html\Tag\P;
+
+final class DialogTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<dialog><p>Content</p></dialog>',
+            (string) (new Dialog())
+                ->content(
+                    (new P())->content('Content'),
+                ),
+        );
+    }
+}

--- a/tests/Tag/DlTest.php
+++ b/tests/Tag/DlTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Dd;
+use Yiisoft\Html\Tag\Dl;
+use Yiisoft\Html\Tag\Dt;
+
+final class DlTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<dl><dt>Term</dt><dd>Definition</dd></dl>',
+            (string) (new Dl())
+                ->content(
+                    (new Dt())->content('Term')
+                    . (new Dd())->content('Definition'),
+                )
+                ->encode(false),
+        );
+    }
+}

--- a/tests/Tag/DtTest.php
+++ b/tests/Tag/DtTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Dt;
+
+final class DtTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<dt class="red">Hello</dt>',
+            (string) (new Dt())
+                ->class('red')
+                ->content('Hello'),
+        );
+    }
+}

--- a/tests/Tag/EmbedTest.php
+++ b/tests/Tag/EmbedTest.php
@@ -48,4 +48,13 @@ final class EmbedTest extends TestCase
             (string) (new Embed())->height(480),
         );
     }
+
+    public function testImmutability(): void
+    {
+        $embed = new Embed();
+        $this->assertNotSame($embed, $embed->src(null));
+        $this->assertNotSame($embed, $embed->type(null));
+        $this->assertNotSame($embed, $embed->width(null));
+        $this->assertNotSame($embed, $embed->height(null));
+    }
 }

--- a/tests/Tag/EmbedTest.php
+++ b/tests/Tag/EmbedTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Embed;
+
+final class EmbedTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<embed>',
+            (string) new Embed(),
+        );
+    }
+
+    public function testSrc(): void
+    {
+        $this->assertSame(
+            '<embed src="https://example.com/video.mp4">',
+            (string) (new Embed())->src('https://example.com/video.mp4'),
+        );
+    }
+
+    public function testType(): void
+    {
+        $this->assertSame(
+            '<embed type="video/mp4">',
+            (string) (new Embed())->type('video/mp4'),
+        );
+    }
+
+    public function testWidth(): void
+    {
+        $this->assertSame(
+            '<embed width="640">',
+            (string) (new Embed())->width(640),
+        );
+    }
+
+    public function testHeight(): void
+    {
+        $this->assertSame(
+            '<embed height="480">',
+            (string) (new Embed())->height(480),
+        );
+    }
+}

--- a/tests/Tag/FigcaptionTest.php
+++ b/tests/Tag/FigcaptionTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Figcaption;
+
+final class FigcaptionTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<figcaption class="red">Hello</figcaption>',
+            (string) (new Figcaption())
+                ->class('red')
+                ->content('Hello'),
+        );
+    }
+}

--- a/tests/Tag/FigureTest.php
+++ b/tests/Tag/FigureTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Figcaption;
+use Yiisoft\Html\Tag\Figure;
+use Yiisoft\Html\Tag\P;
+
+final class FigureTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<figure><figcaption>Caption</figcaption><p>Content</p></figure>',
+            (string) (new Figure())
+                ->content(
+                    (new Figcaption())->content('Caption')
+                    . (new P())->content('Content'),
+                )
+                ->encode(false),
+        );
+    }
+}

--- a/tests/Tag/HeadTest.php
+++ b/tests/Tag/HeadTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Head;
+use Yiisoft\Html\Tag\Meta;
+use Yiisoft\Html\Tag\Title;
+
+final class HeadTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<head><title>Page Title</title><meta charset="utf-8"></head>',
+            (string) (new Head())
+                ->content(
+                    (new Title())->content('Page Title')
+                    . (new Meta())->charset('utf-8'),
+                )
+                ->encode(false),
+        );
+    }
+}

--- a/tests/Tag/IframeTest.php
+++ b/tests/Tag/IframeTest.php
@@ -24,4 +24,10 @@ final class IframeTest extends TestCase
             (string) (new Iframe())->src('https://example.com'),
         );
     }
+
+    public function testImmutability(): void
+    {
+        $iframe = new Iframe();
+        $this->assertNotSame($iframe, $iframe->src(null));
+    }
 }

--- a/tests/Tag/IframeTest.php
+++ b/tests/Tag/IframeTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Iframe;
+
+final class IframeTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<iframe></iframe>',
+            (string) (new Iframe()),
+        );
+    }
+
+    public function testSrc(): void
+    {
+        $this->assertSame(
+            '<iframe src="https://example.com"></iframe>',
+            (string) (new Iframe())->src('https://example.com'),
+        );
+    }
+}

--- a/tests/Tag/InsTest.php
+++ b/tests/Tag/InsTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Ins;
+use Yiisoft\Html\Tag\P;
+
+final class InsTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<ins><p>Added</p></ins>',
+            (string) (new Ins())
+                ->content(
+                    (new P())->content('Added'),
+                ),
+        );
+    }
+
+    public function testCite(): void
+    {
+        $this->assertSame(
+            '<ins cite="https://example.com"><p>Added</p></ins>',
+            (string) (new Ins())
+                ->cite('https://example.com')
+                ->content(
+                    (new P())->content('Added'),
+                ),
+        );
+    }
+
+    public function testDatetime(): void
+    {
+        $this->assertSame(
+            '<ins datetime="2024-01-01"><p>Added</p></ins>',
+            (string) (new Ins())
+                ->datetime('2024-01-01')
+                ->content(
+                    (new P())->content('Added'),
+                ),
+        );
+    }
+}

--- a/tests/Tag/InsTest.php
+++ b/tests/Tag/InsTest.php
@@ -44,4 +44,11 @@ final class InsTest extends TestCase
                 ),
         );
     }
+
+    public function testImmutability(): void
+    {
+        $tag = new Ins();
+        $this->assertNotSame($tag, $tag->cite(null));
+        $this->assertNotSame($tag, $tag->datetime(null));
+    }
 }

--- a/tests/Tag/KbdTest.php
+++ b/tests/Tag/KbdTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Kbd;
+
+final class KbdTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<kbd class="red">Hello</kbd>',
+            (string) (new Kbd())
+                ->class('red')
+                ->content('Hello'),
+        );
+    }
+}

--- a/tests/Tag/MainTest.php
+++ b/tests/Tag/MainTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Main;
+use Yiisoft\Html\Tag\P;
+
+final class MainTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<main><p>Main Content</p></main>',
+            (string) (new Main())
+                ->content(
+                    (new P())->content('Main Content'),
+                ),
+        );
+    }
+}

--- a/tests/Tag/MapTest.php
+++ b/tests/Tag/MapTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Map;
+
+final class MapTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<map class="red">Hello</map>',
+            (string) (new Map())
+                ->class('red')
+                ->content('Hello'),
+        );
+    }
+}

--- a/tests/Tag/MarkTest.php
+++ b/tests/Tag/MarkTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Mark;
+
+final class MarkTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<mark class="red">Hello</mark>',
+            (string) (new Mark())
+                ->class('red')
+                ->content('Hello'),
+        );
+    }
+}

--- a/tests/Tag/MenuTest.php
+++ b/tests/Tag/MenuTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Li;
+use Yiisoft\Html\Tag\Menu;
+
+final class MenuTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            "<menu>\n<li>Item 1</li>\n<li>Item 2</li>\n</menu>",
+            (string) (new Menu())->items(
+                (new Li())->content('Item 1'),
+                (new Li())->content('Item 2'),
+            ),
+        );
+    }
+}

--- a/tests/Tag/MeterTest.php
+++ b/tests/Tag/MeterTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Meter;
+
+final class MeterTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<meter class="red">Hello</meter>',
+            (string) (new Meter())
+                ->class('red')
+                ->content('Hello'),
+        );
+    }
+
+    public function testMin(): void
+    {
+        $this->assertSame(
+            '<meter min="0">Hello</meter>',
+            (string) (new Meter())->min(0)->content('Hello'),
+        );
+    }
+
+    public function testMax(): void
+    {
+        $this->assertSame(
+            '<meter max="100">Hello</meter>',
+            (string) (new Meter())->max(100)->content('Hello'),
+        );
+    }
+
+    public function testValue(): void
+    {
+        $this->assertSame(
+            '<meter value="50">Hello</meter>',
+            (string) (new Meter())->value(50)->content('Hello'),
+        );
+    }
+
+    public function testLow(): void
+    {
+        $this->assertSame(
+            '<meter low="25">Hello</meter>',
+            (string) (new Meter())->low(25)->content('Hello'),
+        );
+    }
+
+    public function testHigh(): void
+    {
+        $this->assertSame(
+            '<meter high="75">Hello</meter>',
+            (string) (new Meter())->high(75)->content('Hello'),
+        );
+    }
+
+    public function testOptimum(): void
+    {
+        $this->assertSame(
+            '<meter optimum="50">Hello</meter>',
+            (string) (new Meter())->optimum(50)->content('Hello'),
+        );
+    }
+}

--- a/tests/Tag/MeterTest.php
+++ b/tests/Tag/MeterTest.php
@@ -66,4 +66,15 @@ final class MeterTest extends TestCase
             (string) (new Meter())->optimum(50)->content('Hello'),
         );
     }
+
+    public function testImmutability(): void
+    {
+        $tag = new Meter();
+        $this->assertNotSame($tag, $tag->min(null));
+        $this->assertNotSame($tag, $tag->max(null));
+        $this->assertNotSame($tag, $tag->value(null));
+        $this->assertNotSame($tag, $tag->low(null));
+        $this->assertNotSame($tag, $tag->high(null));
+        $this->assertNotSame($tag, $tag->optimum(null));
+    }
 }

--- a/tests/Tag/ObjectTest.php
+++ b/tests/Tag/ObjectTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Object_;
+
+final class ObjectTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<object class="red">Content</object>',
+            (string) (new Object_())
+                ->class('red')
+                ->content('Content'),
+        );
+    }
+
+    public function testData(): void
+    {
+        $this->assertSame(
+            '<object data="https://example.com/app">Content</object>',
+            (string) (new Object_())->data('https://example.com/app')->content('Content'),
+        );
+    }
+
+    public function testForm(): void
+    {
+        $this->assertSame(
+            '<object form="form1">Content</object>',
+            (string) (new Object_())->form('form1')->content('Content'),
+        );
+    }
+
+    public function testName(): void
+    {
+        $this->assertSame(
+            '<object name="app">Content</object>',
+            (string) (new Object_())->name('app')->content('Content'),
+        );
+    }
+
+    public function testType(): void
+    {
+        $this->assertSame(
+            '<object type="application/pdf">Content</object>',
+            (string) (new Object_())->type('application/pdf')->content('Content'),
+        );
+    }
+
+    public function testWidth(): void
+    {
+        $this->assertSame(
+            '<object width="640">Content</object>',
+            (string) (new Object_())->width(640)->content('Content'),
+        );
+    }
+
+    public function testHeight(): void
+    {
+        $this->assertSame(
+            '<object height="480">Content</object>',
+            (string) (new Object_())->height(480)->content('Content'),
+        );
+    }
+}

--- a/tests/Tag/ObjectTest.php
+++ b/tests/Tag/ObjectTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Html\Tests\Tag;
 
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Html\Tag\Object_;
+use Yiisoft\Html\Tag\ObjectTag;
 
 final class ObjectTest extends TestCase
 {
@@ -13,7 +13,7 @@ final class ObjectTest extends TestCase
     {
         $this->assertSame(
             '<object class="red">Content</object>',
-            (string) (new Object_())
+            (string) (new ObjectTag())
                 ->class('red')
                 ->content('Content'),
         );
@@ -23,7 +23,7 @@ final class ObjectTest extends TestCase
     {
         $this->assertSame(
             '<object data="https://example.com/app">Content</object>',
-            (string) (new Object_())->data('https://example.com/app')->content('Content'),
+            (string) (new ObjectTag())->data('https://example.com/app')->content('Content'),
         );
     }
 
@@ -31,7 +31,7 @@ final class ObjectTest extends TestCase
     {
         $this->assertSame(
             '<object form="form1">Content</object>',
-            (string) (new Object_())->form('form1')->content('Content'),
+            (string) (new ObjectTag())->form('form1')->content('Content'),
         );
     }
 
@@ -39,7 +39,7 @@ final class ObjectTest extends TestCase
     {
         $this->assertSame(
             '<object name="app">Content</object>',
-            (string) (new Object_())->name('app')->content('Content'),
+            (string) (new ObjectTag())->name('app')->content('Content'),
         );
     }
 
@@ -47,7 +47,7 @@ final class ObjectTest extends TestCase
     {
         $this->assertSame(
             '<object type="application/pdf">Content</object>',
-            (string) (new Object_())->type('application/pdf')->content('Content'),
+            (string) (new ObjectTag())->type('application/pdf')->content('Content'),
         );
     }
 
@@ -55,7 +55,7 @@ final class ObjectTest extends TestCase
     {
         $this->assertSame(
             '<object width="640">Content</object>',
-            (string) (new Object_())->width(640)->content('Content'),
+            (string) (new ObjectTag())->width(640)->content('Content'),
         );
     }
 
@@ -63,7 +63,18 @@ final class ObjectTest extends TestCase
     {
         $this->assertSame(
             '<object height="480">Content</object>',
-            (string) (new Object_())->height(480)->content('Content'),
+            (string) (new ObjectTag())->height(480)->content('Content'),
         );
+    }
+
+    public function testImmutability(): void
+    {
+        $object = new ObjectTag();
+        $this->assertNotSame($object, $object->data(null));
+        $this->assertNotSame($object, $object->form(null));
+        $this->assertNotSame($object, $object->name(null));
+        $this->assertNotSame($object, $object->type(null));
+        $this->assertNotSame($object, $object->width(null));
+        $this->assertNotSame($object, $object->height(null));
     }
 }

--- a/tests/Tag/OutputTest.php
+++ b/tests/Tag/OutputTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Output;
+
+final class OutputTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<output class="red">Hello</output>',
+            (string) (new Output())
+                ->class('red')
+                ->content('Hello'),
+        );
+    }
+}

--- a/tests/Tag/ProgressTest.php
+++ b/tests/Tag/ProgressTest.php
@@ -34,4 +34,11 @@ final class ProgressTest extends TestCase
             (string) (new Progress())->value(50)->content('Hello'),
         );
     }
+
+    public function testImmutability(): void
+    {
+        $tag = new Progress();
+        $this->assertNotSame($tag, $tag->max(null));
+        $this->assertNotSame($tag, $tag->value(null));
+    }
 }

--- a/tests/Tag/ProgressTest.php
+++ b/tests/Tag/ProgressTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Progress;
+
+final class ProgressTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<progress class="red">Hello</progress>',
+            (string) (new Progress())
+                ->class('red')
+                ->content('Hello'),
+        );
+    }
+
+    public function testMax(): void
+    {
+        $this->assertSame(
+            '<progress max="100">Hello</progress>',
+            (string) (new Progress())->max(100)->content('Hello'),
+        );
+    }
+
+    public function testValue(): void
+    {
+        $this->assertSame(
+            '<progress value="50">Hello</progress>',
+            (string) (new Progress())->value(50)->content('Hello'),
+        );
+    }
+}

--- a/tests/Tag/QTest.php
+++ b/tests/Tag/QTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Q;
+
+final class QTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<q class="red">Hello</q>',
+            (string) (new Q())
+                ->class('red')
+                ->content('Hello'),
+        );
+    }
+
+    public function testCite(): void
+    {
+        $this->assertSame(
+            '<q cite="https://example.com">Hello</q>',
+            (string) (new Q())
+                ->cite('https://example.com')
+                ->content('Hello'),
+        );
+    }
+}

--- a/tests/Tag/QTest.php
+++ b/tests/Tag/QTest.php
@@ -28,4 +28,10 @@ final class QTest extends TestCase
                 ->content('Hello'),
         );
     }
+
+    public function testImmutability(): void
+    {
+        $tag = new Q();
+        $this->assertNotSame($tag, $tag->cite(null));
+    }
 }

--- a/tests/Tag/RpTest.php
+++ b/tests/Tag/RpTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Rp;
+
+final class RpTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<rp class="red">Hello</rp>',
+            (string) (new Rp())
+                ->class('red')
+                ->content('Hello'),
+        );
+    }
+}

--- a/tests/Tag/RtTest.php
+++ b/tests/Tag/RtTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Rt;
+
+final class RtTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<rt class="red">Hello</rt>',
+            (string) (new Rt())
+                ->class('red')
+                ->content('Hello'),
+        );
+    }
+}

--- a/tests/Tag/RubyTest.php
+++ b/tests/Tag/RubyTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Ruby;
+
+final class RubyTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<ruby class="red">Hello</ruby>',
+            (string) (new Ruby())
+                ->class('red')
+                ->content('Hello'),
+        );
+    }
+}

--- a/tests/Tag/STest.php
+++ b/tests/Tag/STest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\S;
+
+final class STest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<s class="red">Hello</s>',
+            (string) (new S())
+                ->class('red')
+                ->content('Hello'),
+        );
+    }
+}

--- a/tests/Tag/SampTest.php
+++ b/tests/Tag/SampTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Samp;
+
+final class SampTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<samp class="red">Hello</samp>',
+            (string) (new Samp())
+                ->class('red')
+                ->content('Hello'),
+        );
+    }
+}

--- a/tests/Tag/SearchTest.php
+++ b/tests/Tag/SearchTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Search;
+
+final class SearchTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<search class="red">Hello</search>',
+            (string) (new Search())
+                ->class('red')
+                ->content('Hello'),
+        );
+    }
+}

--- a/tests/Tag/SlotTest.php
+++ b/tests/Tag/SlotTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Slot;
+
+final class SlotTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<slot class="red">Hello</slot>',
+            (string) (new Slot())
+                ->class('red')
+                ->content('Hello'),
+        );
+    }
+}

--- a/tests/Tag/SubTest.php
+++ b/tests/Tag/SubTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Sub;
+
+final class SubTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<sub class="red">Hello</sub>',
+            (string) (new Sub())
+                ->class('red')
+                ->content('Hello'),
+        );
+    }
+}

--- a/tests/Tag/SummaryTest.php
+++ b/tests/Tag/SummaryTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Summary;
+
+final class SummaryTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<summary class="red">Hello</summary>',
+            (string) (new Summary())
+                ->class('red')
+                ->content('Hello'),
+        );
+    }
+}

--- a/tests/Tag/SupTest.php
+++ b/tests/Tag/SupTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Sup;
+
+final class SupTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<sup class="red">Hello</sup>',
+            (string) (new Sup())
+                ->class('red')
+                ->content('Hello'),
+        );
+    }
+}

--- a/tests/Tag/TemplateTest.php
+++ b/tests/Tag/TemplateTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Template;
+
+final class TemplateTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<template class="red">Hello</template>',
+            (string) (new Template())
+                ->class('red')
+                ->content('Hello'),
+        );
+    }
+}

--- a/tests/Tag/TimeTest.php
+++ b/tests/Tag/TimeTest.php
@@ -28,4 +28,10 @@ final class TimeTest extends TestCase
                 ->content('Hello'),
         );
     }
+
+    public function testImmutability(): void
+    {
+        $tag = new Time();
+        $this->assertNotSame($tag, $tag->datetime(null));
+    }
 }

--- a/tests/Tag/TimeTest.php
+++ b/tests/Tag/TimeTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Time;
+
+final class TimeTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<time class="red">Hello</time>',
+            (string) (new Time())
+                ->class('red')
+                ->content('Hello'),
+        );
+    }
+
+    public function testDatetime(): void
+    {
+        $this->assertSame(
+            '<time datetime="2024-01-01">Hello</time>',
+            (string) (new Time())
+                ->datetime('2024-01-01')
+                ->content('Hello'),
+        );
+    }
+}

--- a/tests/Tag/UTest.php
+++ b/tests/Tag/UTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\U;
+
+final class UTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<u class="red">Hello</u>',
+            (string) (new U())
+                ->class('red')
+                ->content('Hello'),
+        );
+    }
+}

--- a/tests/Tag/VarTest.php
+++ b/tests/Tag/VarTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Var_;
+
+final class VarTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<var class="red">Hello</var>',
+            (string) (new Var_())
+                ->class('red')
+                ->content('Hello'),
+        );
+    }
+}

--- a/tests/Tag/VarTest.php
+++ b/tests/Tag/VarTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Html\Tests\Tag;
 
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Html\Tag\Var_;
+use Yiisoft\Html\Tag\VarTag;
 
 final class VarTest extends TestCase
 {
@@ -13,9 +13,15 @@ final class VarTest extends TestCase
     {
         $this->assertSame(
             '<var class="red">Hello</var>',
-            (string) (new Var_())
+            (string) (new VarTag())
                 ->class('red')
                 ->content('Hello'),
         );
+    }
+
+    public function testImmutability(): void
+    {
+        $tag = new VarTag();
+        $this->assertNotSame($tag, $tag->content(''));
     }
 }

--- a/tests/Tag/WbrTest.php
+++ b/tests/Tag/WbrTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Html\Tests\Tag;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Wbr;
+
+final class WbrTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $this->assertSame(
+            '<wbr>',
+            (string) new Wbr(),
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #268

Testing local AI, this Issue seemed a perfect candidate. Close if improper.