### PR TITLE
Fix #279: Add support for conditional CSS classes in `Html::addCssClass()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 4.2.1 under development
 
-- no changes in this release.
+- New #279: Add support for conditional CSS classes in `Html::addCssClass()` (@Mister-42)
 
 ## 4.2.0 June 05, 2026
 

--- a/src/Html.php
+++ b/src/Html.php
@@ -1707,9 +1707,9 @@ final class Html
      * @param array $attributes The attributes to be modified. All string values in the array must be valid UTF-8
      * strings.
      * @param BackedEnum|BackedEnum[]|null[]|string|string[]|null $class The CSS class(es) to be added. Null values will
-     * be ignored.
+     * be ignored. When passing an array, use a boolean value to conditionally include/exclude a class by its key.
      *
-     * @psalm-param BackedEnum|string|array<array-key,BackedEnum|string|null>|null $class
+     * @psalm-param BackedEnum|string|array<array-key,BackedEnum|bool|string|null>|null $class
      */
     public static function addCssClass(array &$attributes, BackedEnum|array|string|null $class): void
     {
@@ -1727,16 +1727,15 @@ final class Html
         if (is_array($class)) {
             $filteredClass = [];
             foreach ($class as $key => $value) {
-                if ($value instanceof BackedEnum) {
-                    $value = is_string($value->value) ? $value->value : null;
-                }
-
-                /** @psalm-suppress DocblockTypeContradiction */
                 if (is_bool($value)) {
                     if ($value && is_string($key)) {
                         $filteredClass[] = $key;
                     }
                     continue;
+                }
+
+                if ($value instanceof BackedEnum) {
+                    $value = is_string($value->value) ? $value->value : null;
                 }
 
                 if ($value !== null) {

--- a/src/Html.php
+++ b/src/Html.php
@@ -1706,7 +1706,7 @@ final class Html
      *
      * @param array $attributes The attributes to be modified. All string values in the array must be valid UTF-8
      * strings.
-     * @param BackedEnum|BackedEnum[]|null[]|string|string[]|null $class The CSS class(es) to be added. Null values will
+     * @param (BackedEnum|null|bool|string)[]|BackedEnum|string|null $class The CSS class(es) to be added. Null values will
      * be ignored. When passing an array, use a boolean value to conditionally include/exclude a class by its key.
      *
      * @psalm-param BackedEnum|string|array<array-key,BackedEnum|bool|string|null>|null $class

--- a/src/Html.php
+++ b/src/Html.php
@@ -1731,6 +1731,13 @@ final class Html
                     $value = is_string($value->value) ? $value->value : null;
                 }
 
+                if (is_bool($value)) {
+                    if ($value && is_string($key)) {
+                        $filteredClass[] = $key;
+                    }
+                    continue;
+                }
+
                 if ($value !== null) {
                     $filteredClass[$key] = $value;
                 }

--- a/src/Html.php
+++ b/src/Html.php
@@ -1731,6 +1731,7 @@ final class Html
                     $value = is_string($value->value) ? $value->value : null;
                 }
 
+                /** @psalm-suppress DocblockTypeContradiction */
                 if (is_bool($value)) {
                     if ($value && is_string($key)) {
                         $filteredClass[] = $key;

--- a/src/Html.php
+++ b/src/Html.php
@@ -1739,7 +1739,11 @@ final class Html
                 }
 
                 if ($value !== null) {
-                    $filteredClass[$key] = $value;
+                    if (is_int($key) && array_key_exists($key, $filteredClass)) {
+                        $filteredClass[] = $value;
+                    } else {
+                        $filteredClass[$key] = $value;
+                    }
                 }
             }
             if (empty($filteredClass)) {

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -1054,7 +1054,10 @@ final class HtmlTest extends TestCase
             21 => [['class' => ['btn', 'btn-active']], [], ['btn', 'btn-active' => true]],
             22 => [['class' => ['btn']], [], ['btn', 'btn-active' => false]],
             23 => [['class' => ['btn', 'btn-active']], ['class' => 'btn'], ['btn-active' => true]],
-            24 => [['class' => 'btn'], ['class' => 'btn'], ['btn-active' => false]],
+             24 => [['class' => 'btn'], ['class' => 'btn'], ['btn-active' => false]],
+             25 => [['class' => ['btn', 'btn-active']], ['class' => 'btn'], ['btn-active' => true, 'hidden' => false]],
+             26 => [['class' => ['btn']], ['class' => 'btn'], ['btn' => true]],
+             27 => [['class' => ['persistent' => 'widget', 'btn', 'btn-active']], ['class' => ['persistent' => 'widget']], ['btn', 'btn-active' => true]],
         ];
     }
 
@@ -1095,20 +1098,6 @@ final class HtmlTest extends TestCase
         $this->assertSame(['persistent' => 'test1'], $attributes['class']);
         Html::addCssClass($attributes, ['additional' => 'test2']);
         $this->assertSame(['persistent' => 'test1', 'additional' => 'test2'], $attributes['class']);
-    }
-
-    public function testAddCssClassConditional(): void
-    {
-        $attributes = ['class' => 'btn'];
-        Html::addCssClass($attributes, ['btn-active' => true, 'hidden' => false]);
-        $this->assertSame(['class' => ['btn', 'btn-active']], $attributes);
-
-        Html::addCssClass($attributes, ['btn' => true]);
-        $this->assertSame(['class' => ['btn', 'btn-active']], $attributes);
-
-        $attributes = ['class' => ['persistent' => 'widget']];
-        Html::addCssClass($attributes, ['btn', 'btn-active' => true]);
-        $this->assertSame(['class' => ['persistent' => 'widget', 'btn', 'btn-active']], $attributes);
     }
 
     public function testAddCssClassArrayToString(): void

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -1049,6 +1049,12 @@ final class HtmlTest extends TestCase
             16 => [['id' => 'w2', 'class' => 't1'], ['id' => 'w2'], 't1'],
             17 => [['id' => 'w2', 'class' => ['t3', 2 => 't4']], ['id' => 'w2'], ['t3', null, 't4']],
             18 => [['id' => 'w2', 'class' => ['t3', 2 => 't4']], ['id' => 'w2'], ['t3', null, 't4', null]],
+            19 => [['class' => ['btn-active']], [], ['btn-active' => true]],
+            20 => [[], [], ['btn-active' => false]],
+            21 => [['class' => ['btn', 'btn-active']], [], ['btn', 'btn-active' => true]],
+            22 => [['class' => ['btn']], [], ['btn', 'btn-active' => false]],
+            23 => [['class' => ['btn', 'btn-active']], ['class' => 'btn'], ['btn-active' => true]],
+            24 => [['class' => 'btn'], ['class' => 'btn'], ['btn-active' => false]],
         ];
     }
 
@@ -1089,6 +1095,20 @@ final class HtmlTest extends TestCase
         $this->assertSame(['persistent' => 'test1'], $attributes['class']);
         Html::addCssClass($attributes, ['additional' => 'test2']);
         $this->assertSame(['persistent' => 'test1', 'additional' => 'test2'], $attributes['class']);
+    }
+
+    public function testAddCssClassConditional(): void
+    {
+        $attributes = ['class' => 'btn'];
+        Html::addCssClass($attributes, ['btn-active' => true, 'hidden' => false]);
+        $this->assertSame(['class' => ['btn', 'btn-active']], $attributes);
+
+        Html::addCssClass($attributes, ['btn' => true]);
+        $this->assertSame(['class' => ['btn', 'btn-active']], $attributes);
+
+        $attributes = ['class' => ['persistent' => 'widget']];
+        Html::addCssClass($attributes, ['btn', 'btn-active' => true]);
+        $this->assertSame(['class' => ['persistent' => 'widget', 'btn', 'btn-active']], $attributes);
     }
 
     public function testAddCssClassArrayToString(): void

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -1054,10 +1054,10 @@ final class HtmlTest extends TestCase
             21 => [['class' => ['btn', 'btn-active']], [], ['btn', 'btn-active' => true]],
             22 => [['class' => ['btn']], [], ['btn', 'btn-active' => false]],
             23 => [['class' => ['btn', 'btn-active']], ['class' => 'btn'], ['btn-active' => true]],
-             24 => [['class' => 'btn'], ['class' => 'btn'], ['btn-active' => false]],
-             25 => [['class' => ['btn', 'btn-active']], ['class' => 'btn'], ['btn-active' => true, 'hidden' => false]],
-             26 => [['class' => ['btn']], ['class' => 'btn'], ['btn' => true]],
-             27 => [['class' => ['persistent' => 'widget', 'btn', 'btn-active']], ['class' => ['persistent' => 'widget']], ['btn', 'btn-active' => true]],
+            24 => [['class' => 'btn'], ['class' => 'btn'], ['btn-active' => false]],
+            25 => [['class' => ['btn', 'btn-active']], ['class' => 'btn'], ['btn-active' => true, 'hidden' => false]],
+            26 => [['class' => ['btn']], ['class' => 'btn'], ['btn' => true]],
+            27 => [['class' => ['persistent' => 'widget', 'btn', 'btn-active']], ['class' => ['persistent' => 'widget']], ['btn', 'btn-active' => true]],
         ];
     }
 

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -1059,7 +1059,7 @@ final class HtmlTest extends TestCase
             26 => [['class' => ['btn']], ['class' => 'btn'], ['btn' => true]],
             27 => [['class' => ['persistent' => 'widget', 'btn', 'btn-active']], ['class' => ['persistent' => 'widget']], ['btn', 'btn-active' => true]],
             28 => [['class' => ['persistent' => 'widget', 'btn-active', 'btn']], ['class' => ['persistent' => 'widget']], ['btn-active' => true, 'btn']],
-            29 => [['class' => ['persistent' => 'widget', 'btn-active', 'btn']], ['class' => ['persistent' => 'widget']], ['btn-active' => true, 'btn-sm' => false, 'btn']],
+            29 => [['class' => ['persistent' => 'widget', 'btn-active', 'btn', 'btn-sm']], ['class' => ['persistent' => 'widget']], ['btn-active' => true, 'btn', 'btn-sm' => true]],
         ];
     }
 

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -1058,6 +1058,8 @@ final class HtmlTest extends TestCase
             25 => [['class' => ['btn', 'btn-active']], ['class' => 'btn'], ['btn-active' => true, 'hidden' => false]],
             26 => [['class' => ['btn']], ['class' => 'btn'], ['btn' => true]],
             27 => [['class' => ['persistent' => 'widget', 'btn', 'btn-active']], ['class' => ['persistent' => 'widget']], ['btn', 'btn-active' => true]],
+            28 => [['class' => ['persistent' => 'widget', 'btn-active', 'btn']], ['class' => ['persistent' => 'widget']], ['btn-active' => true, 'btn']],
+            29 => [['class' => ['persistent' => 'widget', 'btn-active', 'btn']], ['class' => ['persistent' => 'widget']], ['btn-active' => true, 'btn-sm' => false, 'btn']],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #275
